### PR TITLE
chore(cloudbuild): Update min-instances to 1 for deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
   args: ['run', 'deploy', '$_REPO_NAME',
          '--image', 'asia.gcr.io/$_PROJ_NAME/$_REPO_NAME/$_IMG_NAME',
          '--region', 'asia-southeast1',
-         '--min-instances', '0',
+         '--min-instances', '1',
          '--max-instances', '49',
          '--update-secrets', 'firebase_secret=firebase-realtime-database:latest',
          '--memory', '8Gi',


### PR DESCRIPTION
Adjust the minimum instances setting in cloudbuild.yaml to ensure at least one instance is running during deployment for better availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to keep one Cloud Run instance always warm, preserving existing limits (region, max instances, memory, concurrency, timeout, CPU, secrets).
* **Impact**
  * Faster initial response times by reducing cold starts for first requests after idle periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->