### PR TITLE
feat(home-risk): add age-group heat risk profiles

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -76,9 +76,9 @@ Request body:
 - `longitude: number`
   Range `[-180, 180]`.
 - `profile: string`
-  Must be `ADULT` or `KIDS`. Both profiles currently use the same pythermalcomfort
-  model path; the field is included to reserve the public contract for future
-  profile-specific behaviour.
+  Must be one of `ADULT`, `UNDER_10`, `AGE_10_13`, or `AGE_14_17`. All profiles
+  currently use the same pythermalcomfort model path; the field is included to
+  preserve the public contract for future profile-specific behaviour.
 
 Example request:
 
@@ -87,7 +87,7 @@ Example request:
   "sport": "SOCCER",
   "latitude": -33.847,
   "longitude": 151.067,
-  "profile": "ADULT"
+  "profile": "AGE_10_13"
 }
 ```
 
@@ -105,7 +105,7 @@ Example response:
 {
   "request": {
     "sport": "SOCCER",
-    "profile": "ADULT",
+    "profile": "AGE_10_13",
     "location": {
       "latitude": -33.847,
       "longitude": 151.067,

--- a/backend/src/sma_extreme_heat_backend/schemas/home.py
+++ b/backend/src/sma_extreme_heat_backend/schemas/home.py
@@ -13,7 +13,9 @@ class RiskProfile(StrEnum):
     """Public profile values accepted by the home-risk API."""
 
     ADULT = "ADULT"
-    KIDS = "KIDS"
+    UNDER_10 = "UNDER_10"
+    AGE_10_13 = "AGE_10_13"
+    AGE_14_17 = "AGE_14_17"
 
 
 class RiskRequest(BaseModel):

--- a/backend/src/sma_extreme_heat_backend/services/risk_service.py
+++ b/backend/src/sma_extreme_heat_backend/services/risk_service.py
@@ -110,8 +110,8 @@ class RiskService:
         if hourly_mrt_df.empty:
             raise WeatherProviderError("No hourly record after 30-minute resample")
 
-        # `ADULT` and `KIDS` already flow through the public contract and cache key,
-        # but both profiles currently use the same pythermalcomfort model path.
+        # Profiles already flow through the public contract and cache key, but
+        # all supported age groups currently use the same pythermalcomfort model path.
         response = RiskResponse(
             request=RequestSummary(
                 sport=payload.sport,

--- a/backend/tests/api/test_home_risk.py
+++ b/backend/tests/api/test_home_risk.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from sma_extreme_heat_backend.api.routes import get_risk_service
@@ -15,6 +16,8 @@ from sma_extreme_heat_backend.schemas.home import (
     RiskResponse,
 )
 
+VALID_PROFILES = ("ADULT", "UNDER_10", "AGE_10_13", "AGE_14_17")
+
 
 class SuccessfulRiskService:
     """Route test double that returns a valid forecast-centric response."""
@@ -25,11 +28,11 @@ class SuccessfulRiskService:
         assert payload.sport == "SOCCER"
         assert payload.latitude == -33.847
         assert payload.longitude == 151.067
-        assert payload.profile == "ADULT"
+        assert payload.profile in VALID_PROFILES
         return RiskResponse(
             request=RequestSummary(
                 sport="SOCCER",
-                profile="ADULT",
+                profile=payload.profile,
                 location=LocationSummary(
                     latitude=-33.847,
                     longitude=151.067,
@@ -105,7 +108,8 @@ class MissingInputRiskService:
         )
 
 
-def test_post_home_risk_success_returns_forecast_centric_contract() -> None:
+@pytest.mark.parametrize("profile", VALID_PROFILES)
+def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) -> None:
     """The route should serialize the new forecast-centric response contract."""
 
     app = create_app()
@@ -115,7 +119,7 @@ def test_post_home_risk_success_returns_forecast_centric_contract() -> None:
         "sport": "SOCCER",
         "latitude": -33.847,
         "longitude": 151.067,
-        "profile": "ADULT",
+        "profile": profile,
     }
 
     with TestClient(app) as client:
@@ -125,7 +129,7 @@ def test_post_home_risk_success_returns_forecast_centric_contract() -> None:
     assert response.json() == {
         "request": {
             "sport": "SOCCER",
-            "profile": "ADULT",
+            "profile": profile,
             "location": {
                 "latitude": -33.847,
                 "longitude": 151.067,
@@ -259,7 +263,7 @@ def test_post_home_risk_invalid_profile_returns_422() -> None:
                 "sport": "SOCCER",
                 "latitude": -33.847,
                 "longitude": 151.067,
-                "profile": "Adult",
+                "profile": "KIDS",
             },
         )
 

--- a/backend/tests/services/test_risk_service.py
+++ b/backend/tests/services/test_risk_service.py
@@ -14,6 +14,8 @@ from sma_extreme_heat_backend.core.errors import ModelInputUnavailableError
 from sma_extreme_heat_backend.schemas.home import RiskRequest
 from sma_extreme_heat_backend.services.risk_service import RiskService
 
+VALID_PROFILES = ("ADULT", "UNDER_10", "AGE_10_13", "AGE_14_17")
+
 
 class FakeWeatherClient:
     """Test double that returns a deterministic hourly forecast."""
@@ -291,8 +293,17 @@ async def test_risk_service_cache_key_changes_with_coordinates(
     assert calculator.calls == 6
 
 
+@pytest.mark.parametrize(
+    ("first_profile", "second_profile"),
+    [
+        ("ADULT", "UNDER_10"),
+        ("AGE_10_13", "AGE_14_17"),
+    ],
+)
 async def test_risk_service_cache_key_changes_with_profile(
     monkeypatch: pytest.MonkeyPatch,
+    first_profile: str,
+    second_profile: str,
 ) -> None:
     """Profile changes should produce independent cache entries."""
 
@@ -310,7 +321,7 @@ async def test_risk_service_cache_key_changes_with_profile(
             sport="SOCCER",
             latitude=-33.847,
             longitude=151.067,
-            profile="ADULT",
+            profile=first_profile,
         )
     )
     await service.calculate_home_risk(
@@ -318,7 +329,7 @@ async def test_risk_service_cache_key_changes_with_profile(
             sport="SOCCER",
             latitude=-33.847,
             longitude=151.067,
-            profile="KIDS",
+            profile=second_profile,
         )
     )
 
@@ -326,10 +337,12 @@ async def test_risk_service_cache_key_changes_with_profile(
     assert calculator.calls == 6
 
 
-async def test_risk_service_returns_same_forecast_for_adult_and_kids_profiles(
+@pytest.mark.parametrize("profile", VALID_PROFILES)
+async def test_risk_service_returns_same_forecast_for_all_profiles(
     monkeypatch: pytest.MonkeyPatch,
+    profile: str,
 ) -> None:
-    """Adult and kids currently map to the same pythermalcomfort model path."""
+    """All supported profiles currently map to the same pythermalcomfort model path."""
 
     _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
 
@@ -338,7 +351,7 @@ async def test_risk_service_returns_same_forecast_for_adult_and_kids_profiles(
         calculator=FakeCalculator(),
         ttl_seconds=600,
     )
-    kids_service = RiskService(
+    comparison_service = RiskService(
         weather_client=FakeWeatherClient(),
         calculator=FakeCalculator(),
         ttl_seconds=600,
@@ -352,19 +365,19 @@ async def test_risk_service_returns_same_forecast_for_adult_and_kids_profiles(
             profile="ADULT",
         )
     )
-    kids = await kids_service.calculate_home_risk(
+    comparison = await comparison_service.calculate_home_risk(
         RiskRequest(
             sport="SOCCER",
             latitude=-33.847,
             longitude=151.067,
-            profile="KIDS",
+            profile=profile,
         )
     )
 
     assert adult.request.profile == "ADULT"
-    assert kids.request.profile == "KIDS"
+    assert comparison.request.profile == profile
     assert [point.model_dump() for point in adult.forecast] == [
-        point.model_dump() for point in kids.forecast
+        point.model_dump() for point in comparison.forecast
     ]
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -79,14 +79,17 @@ Import rules:
 - Risk API response returns a non-empty `forecast[]` plus a nested `request` block containing `sport`, `profile`, and `location`; backend defines `forecast[0]` as the earliest complete forecast point, and frontend derives the current risk from that point while grouping forecast days in the selected location timezone when available, otherwise browser local timezone.
 - Risk is fetched automatically when:
   - a location suggestion is selected (manual or auto-resolved) and coordinates are resolved, and
-  - the sport changes.
+  - the sport changes, and
+  - the selected profile changes.
 - Risk API failures are shown in UI and keep the last valid result (no silent fallback to fixtures).
 - After a successful fetch:
-  - URL query params update (`sport`, `loc`) and
+  - URL query params update (`profile`, `sport`, `loc`) and
   - the last selection is persisted to localStorage only for direct visits (not shared links).
 - Dates are formatted in the selected location timezone when available, otherwise browser local timezone.
 - API time contract: if datetime fields are introduced in request/response payloads, they must use ISO-8601 UTC format (`...Z`).
-- The frontend currently sends `profile: "ADULT"` by default; no kids/adults selector is exposed in the UI yet.
+- The Home filters expose a Profile select above Location and Sport.
+- Public profile values are `ADULT`, `UNDER_10`, `AGE_10_13`, and `AGE_14_17`.
+- The current profile is sent to the backend and restored from shared URLs or local persistence.
 
 ## i18n
 

--- a/frontend/src/api/heatRisk.test.ts
+++ b/frontend/src/api/heatRisk.test.ts
@@ -1,21 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { buildHeatRiskRequest, isHeatRiskApiResponse } from "@/api/heatRisk";
+import { HEAT_RISK_PROFILE_VALUES } from "@/domain/heatRiskProfile";
 
 describe("buildHeatRiskRequest", () => {
-  it("adds the default ADULT profile to the Home risk payload", () => {
-    expect(
-      buildHeatRiskRequest({
+  it.each(HEAT_RISK_PROFILE_VALUES)(
+    "preserves the caller-provided %s profile in the Home risk payload",
+    (profile) => {
+      expect(
+        buildHeatRiskRequest({
+          sport: "SOCCER",
+          latitude: -33.847,
+          longitude: 151.067,
+          profile,
+        }),
+      ).toEqual({
         sport: "SOCCER",
         latitude: -33.847,
         longitude: 151.067,
-      }),
-    ).toEqual({
-      sport: "SOCCER",
-      latitude: -33.847,
-      longitude: 151.067,
-      profile: "ADULT",
-    });
-  });
+        profile,
+      });
+    },
+  );
 });
 
 describe("isHeatRiskApiResponse", () => {
@@ -24,7 +29,7 @@ describe("isHeatRiskApiResponse", () => {
       isHeatRiskApiResponse({
         request: {
           sport: "SOCCER",
-          profile: "ADULT",
+          profile: "AGE_10_13",
           location: {
             latitude: -33.847,
             longitude: 151.067,

--- a/frontend/src/api/heatRisk.ts
+++ b/frontend/src/api/heatRisk.ts
@@ -1,10 +1,10 @@
 import type { SportType } from "@/domain/sport";
 import { endpoints } from "@/api/endpoints";
 import { httpClient } from "@/api/httpClient";
-
-export type HeatRiskProfile = "ADULT" | "KIDS";
-
-export const DEFAULT_HEAT_RISK_PROFILE: HeatRiskProfile = "ADULT";
+import {
+  isHeatRiskProfile,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
 
 export interface HeatRiskRequest {
   sport: SportType;
@@ -69,17 +69,15 @@ export type HeatRiskApiResult =
     };
 
 /**
- * Builds the Home heat-risk request payload using the current default profile.
+ * Builds the Home heat-risk request payload.
  */
 export function buildHeatRiskRequest(payload: {
   sport: SportType;
   latitude: number;
   longitude: number;
+  profile: HeatRiskProfile;
 }): HeatRiskRequest {
-  return {
-    ...payload,
-    profile: DEFAULT_HEAT_RISK_PROFILE,
-  };
+  return payload;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -96,10 +94,6 @@ function isValidIsoDateTime(value: unknown): value is string {
     value.length > 0 &&
     !Number.isNaN(Date.parse(value))
   );
-}
-
-function isHeatRiskProfile(value: unknown): value is HeatRiskProfile {
-  return value === "ADULT" || value === "KIDS";
 }
 
 function isHeatRiskApiData(value: unknown): value is HeatRiskApiData {

--- a/frontend/src/components/home/FiltersSection.tsx
+++ b/frontend/src/components/home/FiltersSection.tsx
@@ -1,15 +1,22 @@
 import {
-  Autocomplete,
   Box,
-  Group,
+  Combobox,
   Image,
+  InputBase,
   Loader,
+  Group,
   Select,
   Stack,
   Text,
+  useCombobox,
 } from "@mantine/core";
-import { useMemo, useState } from "react";
+import { type MouseEvent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  heatRiskProfiles,
+  isHeatRiskProfile,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
 import {
   isSportType,
   sports,
@@ -35,10 +42,22 @@ const SPORT_IMAGE_HEIGHT = 104;
  */
 export function FiltersSection() {
   const { t } = useTranslation();
+  const locationCombobox = useCombobox();
+  const profile = useHomeStore((state) => state.profile);
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
+  const setProfile = useHomeStore((state) => state.setProfile);
   const setSport = useHomeStore((state) => state.setSport);
   const [hasSportImageError, setHasSportImageError] = useState(false);
+
+  const profileOptions = useMemo<SelectOption<HeatRiskProfile>[]>(
+    () =>
+      heatRiskProfiles.map((profileMeta) => ({
+        value: profileMeta.type,
+        label: t(profileMeta.labelKey),
+      })),
+    [t],
+  );
 
   const sportOptions = useMemo<SelectOption<SportType>[]>(
     () =>
@@ -74,6 +93,38 @@ export function FiltersSection() {
   const isShowingCommittedLocation =
     selectedLocation !== null &&
     locationSearchInput === selectedLocation.formattedLocation;
+  const shouldRenderLocationDropdown = suggestionLabels.length > 0;
+  const locationRightSection = isSuggestLoading ? (
+    <Loader size={16} />
+  ) : (
+    <Combobox.Chevron size="md" />
+  );
+  const locationOptions = suggestionLabels.map((label) => (
+    <Combobox.Option value={label} key={label}>
+      {label}
+    </Combobox.Option>
+  ));
+
+  const handleProfileChange = (value: string | null) => {
+    if (value !== null && isHeatRiskProfile(value)) {
+      setProfile(value);
+    }
+  };
+
+  const handleLocationInputClick = (event: MouseEvent<HTMLInputElement>) => {
+    if (isShowingCommittedLocation) {
+      event.currentTarget.select();
+    }
+
+    if (shouldRenderLocationDropdown) {
+      locationCombobox.openDropdown();
+    }
+  };
+
+  const closeLocationDropdown = () => {
+    locationCombobox.closeDropdown();
+    locationCombobox.resetSelectedOption();
+  };
 
   const handleSportChange = (value: string | null) => {
     setHasSportImageError(false);
@@ -92,27 +143,64 @@ export function FiltersSection() {
       <Stack gap={CONTENT_GAP}>
         <Group wrap="nowrap" align="center" gap={CONTENT_GAP}>
           <Text fw={600} w={FIELD_LABEL_WIDTH} ta="right">
+            {t("home.sections.filters.profileLabel")}:
+          </Text>
+          <Box flex={1}>
+            <Select
+              aria-label={t("home.sections.filters.profileLabel")}
+              size="md"
+              data={profileOptions}
+              value={profile}
+              onChange={handleProfileChange}
+              searchable={false}
+              allowDeselect={false}
+            />
+          </Box>
+        </Group>
+
+        <Group wrap="nowrap" align="center" gap={CONTENT_GAP}>
+          <Text fw={600} w={FIELD_LABEL_WIDTH} ta="right">
             {t("home.sections.filters.locationLabel")}:
           </Text>
           <Box flex={1}>
-            <Autocomplete
-              aria-label={t("home.sections.filters.locationLabel")}
-              size="md"
-              placeholder={t("home.sections.filters.locationPlaceholder")}
-              value={locationSearchInput}
-              onChange={onLocationSearchInputChange}
-              onOptionSubmit={onLocationOptionSubmit}
-              onClick={(event) => {
-                if (isShowingCommittedLocation) {
-                  event.currentTarget.select();
-                }
+            <Combobox
+              store={locationCombobox}
+              onOptionSubmit={(value) => {
+                onLocationOptionSubmit(value);
+                closeLocationDropdown();
               }}
-              data={suggestionLabels}
-              filter={({ options }) => options}
-              clearable={false}
-              rightSection={isSuggestLoading ? <Loader size={16} /> : undefined}
-              autoComplete="off"
-            />
+              size="md"
+            >
+              <Combobox.Target targetType="input">
+                <InputBase
+                  __staticSelector="Select"
+                  aria-label={t("home.sections.filters.locationLabel")}
+                  size="md"
+                  placeholder={t("home.sections.filters.locationPlaceholder")}
+                  value={locationSearchInput}
+                  onChange={(event) => {
+                    onLocationSearchInputChange(event.currentTarget.value);
+                    locationCombobox.openDropdown();
+                  }}
+                  onFocus={() => {
+                    if (shouldRenderLocationDropdown) {
+                      locationCombobox.openDropdown();
+                    }
+                  }}
+                  onBlur={closeLocationDropdown}
+                  onClick={handleLocationInputClick}
+                  rightSection={locationRightSection}
+                  rightSectionPointerEvents="none"
+                  autoComplete="off"
+                />
+              </Combobox.Target>
+
+              {shouldRenderLocationDropdown ? (
+                <Combobox.Dropdown>
+                  <Combobox.Options>{locationOptions}</Combobox.Options>
+                </Combobox.Dropdown>
+              ) : null}
+            </Combobox>
           </Box>
         </Group>
 

--- a/frontend/src/domain/heatRiskProfile.test.ts
+++ b/frontend/src/domain/heatRiskProfile.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  HEAT_RISK_PROFILE_VALUES,
+  heatRiskProfiles,
+} from "@/domain/heatRiskProfile";
+
+describe("heatRiskProfiles", () => {
+  it("covers each profile exactly once", () => {
+    const profileTypes = heatRiskProfiles.map((profile) => profile.type);
+
+    expect(profileTypes).toEqual(HEAT_RISK_PROFILE_VALUES);
+    expect(new Set(profileTypes).size).toBe(heatRiskProfiles.length);
+  });
+
+  it("preserves the descending age display order", () => {
+    expect(heatRiskProfiles).toEqual([
+      {
+        type: "ADULT",
+        labelKey: "home.sections.filters.profileAdult",
+        sortOrder: 0,
+      },
+      {
+        type: "AGE_14_17",
+        labelKey: "home.sections.filters.profileAge14To17",
+        sortOrder: 1,
+      },
+      {
+        type: "AGE_10_13",
+        labelKey: "home.sections.filters.profileAge10To13",
+        sortOrder: 2,
+      },
+      {
+        type: "UNDER_10",
+        labelKey: "home.sections.filters.profileUnder10",
+        sortOrder: 3,
+      },
+    ]);
+  });
+});

--- a/frontend/src/domain/heatRiskProfile.ts
+++ b/frontend/src/domain/heatRiskProfile.ts
@@ -1,0 +1,46 @@
+const HEAT_RISK_PROFILE_META = [
+  {
+    type: "ADULT",
+    labelKey: "home.sections.filters.profileAdult",
+    sortOrder: 0,
+  },
+  {
+    type: "AGE_14_17",
+    labelKey: "home.sections.filters.profileAge14To17",
+    sortOrder: 1,
+  },
+  {
+    type: "AGE_10_13",
+    labelKey: "home.sections.filters.profileAge10To13",
+    sortOrder: 2,
+  },
+  {
+    type: "UNDER_10",
+    labelKey: "home.sections.filters.profileUnder10",
+    sortOrder: 3,
+  },
+] as const;
+
+export type HeatRiskProfile = (typeof HEAT_RISK_PROFILE_META)[number]["type"];
+
+export interface HeatRiskProfileMeta {
+  type: HeatRiskProfile;
+  labelKey: string;
+  sortOrder: number;
+}
+
+export const heatRiskProfiles: readonly HeatRiskProfileMeta[] =
+  HEAT_RISK_PROFILE_META;
+
+export const HEAT_RISK_PROFILE_VALUES: HeatRiskProfile[] = heatRiskProfiles.map(
+  (profile) => profile.type,
+);
+
+export const DEFAULT_HEAT_RISK_PROFILE: HeatRiskProfile = "ADULT";
+
+export function isHeatRiskProfile(value: unknown): value is HeatRiskProfile {
+  return (
+    typeof value === "string" &&
+    HEAT_RISK_PROFILE_VALUES.includes(value as HeatRiskProfile)
+  );
+}

--- a/frontend/src/hooks/useHomeHeatRisk.ts
+++ b/frontend/src/hooks/useHomeHeatRisk.ts
@@ -1,7 +1,6 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@mantine/hooks";
 import {
-  DEFAULT_HEAT_RISK_PROFILE,
   buildHeatRiskRequest,
   fetchHeatRisk,
   type HeatRiskApiResponse,
@@ -82,9 +81,11 @@ function toCalculatedHeatRisk(data: HeatRiskApiResponse): {
  * Keeps the last successful risk visible on API errors.
  */
 export function useHomeHeatRisk(): UseHomeHeatRiskResult {
+  const profile = useHomeStore((state) => state.profile);
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
   const [debouncedSport] = useDebouncedValue(sport, 250);
+  const [debouncedProfile] = useDebouncedValue(profile, 250);
 
   const locationCoordinates = toCoordinatesOrNull({
     latitude: selectedLocation?.latitude,
@@ -95,7 +96,7 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
     queryKey: [
       "heatRisk",
       debouncedSport,
-      DEFAULT_HEAT_RISK_PROFILE,
+      debouncedProfile,
       locationCoordinates?.latitude.toFixed(6) ?? "",
       locationCoordinates?.longitude.toFixed(6) ?? "",
     ],
@@ -105,6 +106,7 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
           sport: debouncedSport,
           latitude: locationCoordinates!.latitude,
           longitude: locationCoordinates!.longitude,
+          profile: debouncedProfile,
         }),
         { signal },
       );
@@ -134,7 +136,9 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
     if (
       !locationCoordinates ||
       !debouncedSport ||
+      !debouncedProfile ||
       sport !== debouncedSport ||
+      profile !== debouncedProfile ||
       !selectedLocation
     ) {
       return false;
@@ -150,6 +154,7 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
     locationCoordinates &&
     calculated &&
     !riskQuery.isPlaceholderData &&
+    profile === debouncedProfile &&
     sport === debouncedSport,
   );
 

--- a/frontend/src/hooks/useHomeUrlSync.ts
+++ b/frontend/src/hooks/useHomeUrlSync.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { HeatRiskProfile } from "@/domain/heatRiskProfile";
 import { savePersistedHomeFilters } from "@/pages/home/browserState";
 import type { SetQueryStates } from "@/pages/home/useHomeBootstrap";
 import { useHomeStore } from "@/store/homeStore";
@@ -16,9 +17,14 @@ export function useHomeUrlSync({
   canSyncSelection,
 }: UseHomeUrlSyncParams): void {
   const channel = useHomeStore((state) => state.channel);
+  const profile = useHomeStore((state) => state.profile);
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
-  const lastAppliedRef = useRef<{ sport: string; loc: string } | null>(null);
+  const lastAppliedRef = useRef<{
+    profile: HeatRiskProfile;
+    sport: string;
+    loc: string;
+  } | null>(null);
 
   useEffect(() => {
     if (!canSyncSelection || !selectedLocation) {
@@ -26,11 +32,13 @@ export function useHomeUrlSync({
     }
 
     const nextSelection = {
+      profile,
       sport,
       loc: selectedLocation.formattedLocation,
     };
     const hasSelectionChanged =
       !lastAppliedRef.current ||
+      lastAppliedRef.current.profile !== nextSelection.profile ||
       lastAppliedRef.current.sport !== nextSelection.sport ||
       lastAppliedRef.current.loc !== nextSelection.loc;
 
@@ -41,6 +49,7 @@ export function useHomeUrlSync({
     void (async () => {
       await setQueryStates(
         {
+          profile: nextSelection.profile,
           sport: nextSelection.sport,
           location: nextSelection.loc,
         },
@@ -53,5 +62,12 @@ export function useHomeUrlSync({
 
       lastAppliedRef.current = nextSelection;
     })();
-  }, [canSyncSelection, channel, selectedLocation, setQueryStates, sport]);
+  }, [
+    canSyncSelection,
+    channel,
+    profile,
+    selectedLocation,
+    setQueryStates,
+    sport,
+  ]);
 }

--- a/frontend/src/hooks/useHomeUrlSync.ts
+++ b/frontend/src/hooks/useHomeUrlSync.ts
@@ -25,6 +25,7 @@ export function useHomeUrlSync({
     sport: string;
     loc: string;
   } | null>(null);
+  const syncRunRef = useRef(0);
 
   useEffect(() => {
     if (!canSyncSelection || !selectedLocation) {
@@ -46,6 +47,8 @@ export function useHomeUrlSync({
       return;
     }
 
+    const runId = ++syncRunRef.current;
+
     void (async () => {
       await setQueryStates(
         {
@@ -55,6 +58,10 @@ export function useHomeUrlSync({
         },
         { history: "replace" },
       );
+
+      if (runId !== syncRunRef.current) {
+        return;
+      }
 
       if (channel !== "shared") {
         savePersistedHomeFilters(nextSelection);

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -184,7 +184,7 @@
           {
             "runs": [
               {
-                "text": "Any personal information given to the University will be dealt with in accordance with the University’s Privacy Policy. Any information provided may be accessed by any employee of the University in accordance with the requirements of the University’s Privacy Policy. No personal information is collected by this website. The website stores the user indicated location and sport in local file storage. Some or all of the information provided by the user may be stored in a cloud database in the future. The University may use this information for research and non-commercial purpose only, such as to study the types of users and their usage of the website. The website uses Google Analytics to collect anonymous statistics on the number of visitors to the website, record user activity and approximate location of users based on the detected IP address. All this data is de-identified by Google."
+                "text": "Any personal information given to the University will be dealt with in accordance with the University’s Privacy Policy. Any information provided may be accessed by any employee of the University in accordance with the requirements of the University’s Privacy Policy. No personal information is collected by this website. The website stores the user indicated location, sport, and age group in local file storage. Some or all of the information provided by the user may be stored in a cloud database in the future. The University may use this information for research and non-commercial purpose only, such as to study the types of users and their usage of the website. The website uses Google Analytics to collect anonymous statistics on the number of visitors to the website, record user activity and approximate location of users based on the detected IP address. All this data is de-identified by Google."
               }
             ]
           }
@@ -239,6 +239,11 @@
     },
     "sections": {
       "filters": {
+        "profileLabel": "Age",
+        "profileAdult": "Adult",
+        "profileUnder10": "< 10y",
+        "profileAge10To13": "10–13y",
+        "profileAge14To17": "14–17y",
         "sportLabel": "Sport",
         "locationLabel": "Location",
         "defaultLocation": "North Sydney, Sydney, AU",

--- a/frontend/src/lib/homeRisk.ts
+++ b/frontend/src/lib/homeRisk.ts
@@ -86,7 +86,7 @@ function formatDateParts(
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false,
+    hourCycle: "h23",
     timeZone,
   });
   const parts = formatter.formatToParts(date);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ export function HomePage() {
   const { t } = useTranslation();
   const { setQueryStates } = useHomeBootstrap();
   const { canSyncSelection, hasCalculatedRisk, refresh } = useHomeHeatRisk();
+  const profile = useHomeStore((state) => state.profile);
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
   const [refreshToastEventId, setRefreshToastEventId] = useState(0);
@@ -66,7 +67,7 @@ export function HomePage() {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [hasCalculatedRisk, selectedLocation, sport]);
+  }, [hasCalculatedRisk, profile, selectedLocation, sport]);
 
   return (
     <>

--- a/frontend/src/pages/home/browserState.test.ts
+++ b/frontend/src/pages/home/browserState.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HEAT_RISK_PROFILE_VALUES } from "@/domain/heatRiskProfile";
+import { SportType, SPORT_TYPE_VALUES } from "@/domain/sport";
+import {
+  loadPersistedHomeFilters,
+  savePersistedHomeFilters,
+} from "@/pages/home/browserState";
+
+const HOME_FILTERS_STORAGE_KEY = "home-filters:v1";
+
+interface LocalStorageMock {
+  clear: () => void;
+  getItem: (key: string) => string | null;
+  removeItem: (key: string) => void;
+  setItem: (key: string, value: string) => void;
+}
+
+function installWindowMock(): Map<string, string> {
+  const storage = new Map<string, string>();
+  const localStorage: LocalStorageMock = {
+    clear: () => storage.clear(),
+    getItem: (key) => storage.get(key) ?? null,
+    removeItem: (key) => {
+      storage.delete(key);
+    },
+    setItem: (key, value) => {
+      storage.set(key, value);
+    },
+  };
+
+  vi.stubGlobal("window", {
+    localStorage,
+  });
+
+  return storage;
+}
+
+describe("home browserState", () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = installWindowMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads persisted filters with an explicit profile", () => {
+    storage.set(
+      HOME_FILTERS_STORAGE_KEY,
+      JSON.stringify({
+        profile: "UNDER_10",
+        sport: SportType.Running,
+        loc: "  Perth, AU  ",
+      }),
+    );
+
+    expect(
+      loadPersistedHomeFilters(SPORT_TYPE_VALUES, HEAT_RISK_PROFILE_VALUES),
+    ).toEqual({
+      profile: "UNDER_10",
+      sport: SportType.Running,
+      loc: "Perth, AU",
+    });
+  });
+
+  it("defaults the profile to ADULT for older persisted data", () => {
+    storage.set(
+      HOME_FILTERS_STORAGE_KEY,
+      JSON.stringify({
+        sport: SportType.Basketball,
+        loc: "North Sydney, AU",
+      }),
+    );
+
+    expect(
+      loadPersistedHomeFilters(SPORT_TYPE_VALUES, HEAT_RISK_PROFILE_VALUES),
+    ).toEqual({
+      profile: "ADULT",
+      sport: SportType.Basketball,
+      loc: "North Sydney, AU",
+    });
+  });
+
+  it("defaults the profile to ADULT when persisted data still uses KIDS", () => {
+    storage.set(
+      HOME_FILTERS_STORAGE_KEY,
+      JSON.stringify({
+        profile: "KIDS",
+        sport: SportType.Basketball,
+        loc: "North Sydney, AU",
+      }),
+    );
+
+    expect(
+      loadPersistedHomeFilters(SPORT_TYPE_VALUES, HEAT_RISK_PROFILE_VALUES),
+    ).toEqual({
+      profile: "ADULT",
+      sport: SportType.Basketball,
+      loc: "North Sydney, AU",
+    });
+  });
+
+  it("persists the current profile with the latest filters", () => {
+    savePersistedHomeFilters({
+      profile: "AGE_14_17",
+      sport: SportType.Soccer,
+      loc: "Campbell Creek, QLD, 4625",
+    });
+
+    expect(storage.get(HOME_FILTERS_STORAGE_KEY)).toBe(
+      JSON.stringify({
+        profile: "AGE_14_17",
+        sport: SportType.Soccer,
+        loc: "Campbell Creek, QLD, 4625",
+      }),
+    );
+  });
+});

--- a/frontend/src/pages/home/browserState.ts
+++ b/frontend/src/pages/home/browserState.ts
@@ -1,8 +1,14 @@
+import {
+  DEFAULT_HEAT_RISK_PROFILE,
+  isHeatRiskProfile,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
 import type { SportType } from "@/domain/sport";
 
 const HOME_FILTERS_STORAGE_KEY = "home-filters:v1";
 
 export interface PersistedHomeFilters {
+  profile: HeatRiskProfile;
   sport: SportType;
   loc: string;
 }
@@ -28,6 +34,7 @@ export function isValidPersistedSport(
  */
 export function loadPersistedHomeFilters(
   allowedSports: readonly SportType[],
+  allowedProfiles: readonly HeatRiskProfile[],
 ): PersistedHomeFilters | null {
   if (typeof window === "undefined") {
     return null;
@@ -44,6 +51,7 @@ export function loadPersistedHomeFilters(
       return null;
     }
 
+    const profile = parsed.profile;
     const sport = parsed.sport;
     const loc = parsed.loc;
 
@@ -61,6 +69,10 @@ export function loadPersistedHomeFilters(
     }
 
     return {
+      profile:
+        isHeatRiskProfile(profile) && allowedProfiles.includes(profile)
+          ? profile
+          : DEFAULT_HEAT_RISK_PROFILE,
       sport,
       loc: trimmedLoc,
     };
@@ -84,6 +96,7 @@ export function savePersistedHomeFilters(filters: PersistedHomeFilters): void {
 
   try {
     const payload: PersistedHomeFilters = {
+      profile: filters.profile,
       sport: filters.sport,
       loc: trimmedLoc,
     };

--- a/frontend/src/pages/home/homeBootstrap.test.ts
+++ b/frontend/src/pages/home/homeBootstrap.test.ts
@@ -1,23 +1,29 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_HEAT_RISK_PROFILE } from "@/domain/heatRiskProfile";
 import { DEFAULT_SPORT_TYPE, SportType } from "@/domain/sport";
+import type { PersistedHomeFilters } from "@/pages/home/browserState";
 import { resolveHomeBootstrapState } from "@/pages/home/homeBootstrap";
 
 describe("resolveHomeBootstrapState", () => {
-  it("prefers URL state over persisted filters", () => {
+  it("prefers URL profile and filters over persisted values", () => {
     expect(
       resolveHomeBootstrapState({
         hasUrlState: true,
+        defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
         defaultSport: DEFAULT_SPORT_TYPE,
         defaultLocationLabel: "Sydney, AU",
+        urlProfile: "AGE_10_13",
         urlSport: SportType.Basketball,
         urlLocation: "  Perth, AU  ",
         persistedFilters: {
+          profile: "UNDER_10",
           sport: SportType.Running,
           loc: "Dampier, AU",
         },
       }),
     ).toEqual({
       channel: "shared",
+      profile: "AGE_10_13",
       sport: SportType.Basketball,
       locationSearchInput: "Perth, AU",
       locationPrefillSource: "url",
@@ -29,17 +35,21 @@ describe("resolveHomeBootstrapState", () => {
     expect(
       resolveHomeBootstrapState({
         hasUrlState: false,
+        defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
         defaultSport: DEFAULT_SPORT_TYPE,
         defaultLocationLabel: "Sydney, AU",
+        urlProfile: null,
         urlSport: null,
         urlLocation: null,
         persistedFilters: {
+          profile: "AGE_14_17",
           sport: SportType.Running,
           loc: "  Dampier, AU  ",
         },
       }),
     ).toEqual({
       channel: "direct",
+      profile: "AGE_14_17",
       sport: SportType.Running,
       locationSearchInput: "Dampier, AU",
       locationPrefillSource: "persisted",
@@ -51,17 +61,45 @@ describe("resolveHomeBootstrapState", () => {
     expect(
       resolveHomeBootstrapState({
         hasUrlState: false,
+        defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
         defaultSport: DEFAULT_SPORT_TYPE,
         defaultLocationLabel: "  Sydney, AU  ",
+        urlProfile: null,
         urlSport: null,
         urlLocation: null,
         persistedFilters: null,
       }),
     ).toEqual({
       channel: "direct",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
       sport: DEFAULT_SPORT_TYPE,
       locationSearchInput: "Sydney, AU",
       locationPrefillSource: "default",
+      shouldAutoResolvePrefilledLocation: true,
+    });
+  });
+
+  it("falls back to the default profile when persisted data has no profile", () => {
+    expect(
+      resolveHomeBootstrapState({
+        hasUrlState: false,
+        defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
+        defaultSport: DEFAULT_SPORT_TYPE,
+        defaultLocationLabel: "Sydney, AU",
+        urlProfile: null,
+        urlSport: null,
+        urlLocation: null,
+        persistedFilters: {
+          sport: SportType.Running,
+          loc: "Perth, AU",
+        } as PersistedHomeFilters,
+      }),
+    ).toEqual({
+      channel: "direct",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: SportType.Running,
+      locationSearchInput: "Perth, AU",
+      locationPrefillSource: "persisted",
       shouldAutoResolvePrefilledLocation: true,
     });
   });

--- a/frontend/src/pages/home/homeBootstrap.ts
+++ b/frontend/src/pages/home/homeBootstrap.ts
@@ -1,3 +1,4 @@
+import type { HeatRiskProfile } from "@/domain/heatRiskProfile";
 import type { SportType } from "@/domain/sport";
 import type { PersistedHomeFilters } from "@/pages/home/browserState";
 import type {
@@ -8,8 +9,10 @@ import type {
 
 interface ResolveHomeBootstrapStateParams {
   hasUrlState: boolean;
+  defaultProfile: HeatRiskProfile;
   defaultSport: SportType;
   defaultLocationLabel: string;
+  urlProfile: HeatRiskProfile | null;
   urlSport: SportType | null;
   urlLocation: string | null;
   persistedFilters: PersistedHomeFilters | null;
@@ -29,19 +32,26 @@ export function resolveInitialLocationLabel(
  */
 export function resolveHomeBootstrapState({
   hasUrlState,
+  defaultProfile,
   defaultSport,
   defaultLocationLabel,
+  urlProfile,
   urlSport,
   urlLocation,
   persistedFilters,
 }: ResolveHomeBootstrapStateParams): HomeStoreBootstrapPayload {
   const channel: HomeChannel = hasUrlState ? "shared" : "direct";
 
+  let profile = defaultProfile;
   let sport = defaultSport;
   let locationSearchInput = "";
   let locationPrefillSource: LocationPrefillSource = "none";
 
   if (channel === "shared") {
+    if (urlProfile) {
+      profile = urlProfile;
+    }
+
     if (urlSport) {
       sport = urlSport;
     }
@@ -51,6 +61,7 @@ export function resolveHomeBootstrapState({
       locationPrefillSource = "url";
     }
   } else if (persistedFilters) {
+    profile = persistedFilters.profile ?? defaultProfile;
     sport = persistedFilters.sport;
     locationSearchInput = resolveInitialLocationLabel(persistedFilters.loc);
     if (locationSearchInput.length > 0) {
@@ -67,6 +78,7 @@ export function resolveHomeBootstrapState({
 
   return {
     channel,
+    profile,
     sport,
     locationSearchInput,
     locationPrefillSource,

--- a/frontend/src/pages/home/homeUrlState.ts
+++ b/frontend/src/pages/home/homeUrlState.ts
@@ -1,9 +1,17 @@
 import { parseAsString, parseAsStringEnum } from "nuqs";
+import {
+  HEAT_RISK_PROFILE_VALUES,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
 import { SPORT_TYPE_VALUES } from "@/domain/sport";
 
+export const VALID_PROFILE_VALUES: HeatRiskProfile[] = [
+  ...HEAT_RISK_PROFILE_VALUES,
+];
 export const VALID_SPORT_VALUES = SPORT_TYPE_VALUES;
 
 export const HOME_QUERY_PARSERS = {
+  profile: parseAsStringEnum<HeatRiskProfile>(VALID_PROFILE_VALUES),
   sport: parseAsStringEnum(VALID_SPORT_VALUES),
   location: parseAsString,
 };

--- a/frontend/src/pages/home/useHomeBootstrap.ts
+++ b/frontend/src/pages/home/useHomeBootstrap.ts
@@ -2,12 +2,17 @@ import { useQueryStates } from "nuqs";
 import { useOptimisticSearchParams } from "nuqs/adapters/react-router/v7";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  DEFAULT_HEAT_RISK_PROFILE,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
 import { DEFAULT_SPORT_TYPE, type SportType } from "@/domain/sport";
 import { loadPersistedHomeFilters } from "@/pages/home/browserState";
 import { resolveHomeBootstrapState } from "@/pages/home/homeBootstrap";
 import {
   HOME_QUERY_PARSERS,
   HOME_QUERY_URL_KEYS,
+  VALID_PROFILE_VALUES,
   VALID_SPORT_VALUES,
 } from "@/pages/home/homeUrlState";
 import {
@@ -16,6 +21,7 @@ import {
 } from "@/store/homeStore";
 
 interface SetQueryStateValues {
+  profile: HeatRiskProfile | null;
   sport: SportType | null;
   location: string | null;
 }
@@ -36,15 +42,22 @@ interface UseHomeBootstrapResult {
 export function useHomeBootstrap(): UseHomeBootstrapResult {
   const { t } = useTranslation();
   const optimisticSearchParams = useOptimisticSearchParams();
-  const [{ sport: urlSport, location: urlLocation }, setQueryStates] =
-    useQueryStates(HOME_QUERY_PARSERS, {
-      urlKeys: HOME_QUERY_URL_KEYS,
-    });
+  const [
+    { profile: urlProfile, sport: urlSport, location: urlLocation },
+    setQueryStates,
+  ] = useQueryStates(HOME_QUERY_PARSERS, {
+    urlKeys: HOME_QUERY_URL_KEYS,
+  });
 
   const hasUrlState =
-    optimisticSearchParams.has("sport") || optimisticSearchParams.has("loc");
+    optimisticSearchParams.has("profile") ||
+    optimisticSearchParams.has("sport") ||
+    optimisticSearchParams.has("loc");
   const persistedFilters = useMemo(
-    () => (hasUrlState ? null : loadPersistedHomeFilters(VALID_SPORT_VALUES)),
+    () =>
+      hasUrlState
+        ? null
+        : loadPersistedHomeFilters(VALID_SPORT_VALUES, VALID_PROFILE_VALUES),
     [hasUrlState],
   );
 
@@ -52,13 +65,15 @@ export function useHomeBootstrap(): UseHomeBootstrapResult {
     () =>
       resolveHomeBootstrapState({
         hasUrlState,
+        defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
         defaultSport: DEFAULT_SPORT_TYPE,
         defaultLocationLabel: t("home.sections.filters.defaultLocation"),
+        urlProfile,
         urlSport,
         urlLocation,
         persistedFilters,
       }),
-    [hasUrlState, persistedFilters, t, urlLocation, urlSport],
+    [hasUrlState, persistedFilters, t, urlLocation, urlProfile, urlSport],
   );
 
   useEffect(() => {

--- a/frontend/src/store/homeStore.test.ts
+++ b/frontend/src/store/homeStore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_HEAT_RISK_PROFILE } from "@/domain/heatRiskProfile";
 import type { LocationSuggestion } from "@/domain/location";
 import { DEFAULT_SPORT_TYPE } from "@/domain/sport";
 import { useHomeStore } from "@/store/homeStore";
@@ -31,6 +32,7 @@ function resetHomeStore() {
   useHomeStore.setState({
     isBootstrapped: false,
     channel: "direct",
+    profile: DEFAULT_HEAT_RISK_PROFILE,
     sport: DEFAULT_SPORT_TYPE,
     locationSearchInput: "",
     locationPrefillSource: "none",
@@ -98,6 +100,20 @@ describe("homeStore location search", () => {
     expect(useHomeStore.getState()).toMatchObject({
       locationSearchInput: PERTH_LOCATION.formattedLocation,
       selectedLocation: PERTH_LOCATION,
+    });
+  });
+
+  it("keeps the current sport and location selection when the profile changes", () => {
+    useHomeStore.getState().setSport("RUNNING");
+    useHomeStore.getState().selectLocation(DAMPER_LOCATION);
+
+    useHomeStore.getState().setProfile("AGE_14_17");
+
+    expect(useHomeStore.getState()).toMatchObject({
+      profile: "AGE_14_17",
+      sport: "RUNNING",
+      locationSearchInput: DAMPER_LOCATION.formattedLocation,
+      selectedLocation: DAMPER_LOCATION,
     });
   });
 });

--- a/frontend/src/store/homeStore.ts
+++ b/frontend/src/store/homeStore.ts
@@ -1,5 +1,9 @@
 import { create } from "zustand";
 import type { LocationSuggestion } from "@/domain/location";
+import {
+  DEFAULT_HEAT_RISK_PROFILE,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
 import { DEFAULT_SPORT_TYPE, type SportType } from "@/domain/sport";
 
 export type HomeChannel = "shared" | "direct";
@@ -7,6 +11,7 @@ export type LocationPrefillSource = "url" | "persisted" | "default" | "none";
 
 export interface HomeStoreBootstrapPayload {
   channel: HomeChannel;
+  profile: HeatRiskProfile;
   sport: SportType;
   locationSearchInput: string;
   locationPrefillSource: LocationPrefillSource;
@@ -16,6 +21,7 @@ export interface HomeStoreBootstrapPayload {
 interface HomeStoreState {
   isBootstrapped: boolean;
   channel: HomeChannel;
+  profile: HeatRiskProfile;
   sport: SportType;
   locationSearchInput: string;
   locationPrefillSource: LocationPrefillSource;
@@ -25,6 +31,7 @@ interface HomeStoreState {
   locationSessionToken: string;
 
   bootstrap: (payload: HomeStoreBootstrapPayload) => void;
+  setProfile: (profile: HeatRiskProfile) => void;
   setSport: (sport: SportType) => void;
   setLocationSearchInput: (value: string) => void;
   selectLocation: (suggestion: LocationSuggestion) => void;
@@ -49,6 +56,7 @@ function createSessionToken(): string {
 export const useHomeStore = create<HomeStoreState>((set) => ({
   isBootstrapped: false,
   channel: "direct",
+  profile: DEFAULT_HEAT_RISK_PROFILE,
   sport: DEFAULT_SPORT_TYPE,
   locationSearchInput: "",
   locationPrefillSource: "none",
@@ -59,6 +67,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
 
   bootstrap: ({
     channel,
+    profile,
     sport,
     locationSearchInput,
     locationPrefillSource,
@@ -67,6 +76,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
     set({
       isBootstrapped: true,
       channel,
+      profile,
       sport,
       locationSearchInput,
       locationPrefillSource,
@@ -75,6 +85,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
       hasPrefilledLocationNotMatched: false,
       locationSessionToken: createSessionToken(),
     }),
+  setProfile: (profile) => set({ profile }),
   setSport: (sport) => set({ sport }),
   setLocationSearchInput: (value) =>
     set((state) => {


### PR DESCRIPTION
- replace the legacy KIDS profile with UNDER_10, AGE_10_13, and AGE_14_17
- add profile selection to the Home filters and sync it through URL and local storage
- pass the selected profile through the frontend and backend contracts with updated tests and docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Age/Profile selector in Home with options: Adult, Under 10, 10–13, 14–17
  * Profile selection persists locally and is restored on revisit
  * Profile is included in shareable URLs and triggers automatic risk refetch when changed

* **Documentation**
  * API and READMEs updated to list the expanded profile values and example payloads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->