### PR TITLE
fix!: correct forecast time handling for non-hour-offset timezones [BREAKING CHANGE]

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -47,9 +47,8 @@
 - Request requires `latitude` and `longitude`.
 - `sport` must be official pythermalcomfort `Sports` enum name (e.g. `SOCCER`).
 - Response shape:
-  - `heat_risk` -> raw pythermalcomfort output keys
-  - `meta_data` -> context and source payload references, including `location.timezone` when resolved (no mapbox payload)
-  - `forecast` -> UTC hourly points with `time_utc` and `risk_level_interpolated`
+  - `request` -> request context including `sport`, `profile`, and `location.timezone`
+  - `forecast` -> hourly points with `time_utc`, `time_local`, explicit inputs, and raw pythermalcomfort output keys under `heat_risk`
 - API contract style is snake_case only; do not default to camelCase request keys or legacy `data/meta` response keys.
 - Validate request/response schemas at boundaries; do not rely on implicit dict shapes in route handlers.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -118,6 +118,7 @@ Example response:
   "forecast": [
     {
       "time_utc": "2026-03-09T00:00:00Z",
+      "time_local": "2026-03-09T11:00:00+11:00",
       "inputs": {
         "air_temperature_c": 31.0,
         "mean_radiant_temperature_c": 37.25,
@@ -145,18 +146,19 @@ Example response:
    - `relative_humidity_2m`
    - `wind_speed_10m`
    - `direct_normal_irradiance`
-   - `timezone=GMT`
+   - `timezone=<resolved IANA timezone>`
    - `wind_speed_unit=ms`
 2. Validate provider units at runtime:
    - `temperature_2m: °C`
    - `relative_humidity_2m: %`
    - `wind_speed_10m: m/s`
    - `direct_normal_irradiance: W/m²`
-3. Resolve the IANA timezone from `latitude` and `longitude`.
+3. Resolve the IANA timezone from `latitude` and `longitude`, then require the
+   provider response to echo back the same timezone.
 4. Keep hourly records where `time >= now_utc - 1h` inside the 7-day forecast window.
 5. Convert the retained rows into the resolved local timezone.
-6. Drop rows missing `tdb`, resample to `30min`, and interpolate numeric weather fields.
-7. Build MRT values with `pvlib` + `pythermalcomfort`:
+6. Drop rows missing `tdb`.
+7. Build MRT values with `pvlib` + `pythermalcomfort` on the provider-native hourly points:
    - compute solar elevation for each local timestamp
    - clamp negative solar elevations to `0`
    - derive `dni = direct_normal_irradiance * 0.75`
@@ -193,4 +195,5 @@ Example response:
 - Mean radiant temperature is not assumed to equal dry-bulb air temperature.
   The backend derives MRT through the solar-gain pipeline and returns the final
   `mean_radiant_temperature_c` in each forecast point.
-- The public response does not expose the raw Open-Meteo payload.
+- Each forecast point exposes both `time_utc` and `time_local`; `time_utc` is the
+  canonical instant, while `time_local` is the location-local display time.

--- a/backend/src/sma_extreme_heat_backend/clients/open_meteo.py
+++ b/backend/src/sma_extreme_heat_backend/clients/open_meteo.py
@@ -28,7 +28,6 @@ _EXPECTED_HOURLY_UNITS: dict[str, set[str]] = {
 class HourlyWeatherPoint:
     """Normalized hourly weather point parsed from Open-Meteo."""
 
-    raw_time: str
     time_utc: datetime
     tdb: float | None
     rh: float | None
@@ -38,11 +37,9 @@ class HourlyWeatherPoint:
 
 @dataclass(frozen=True)
 class WeatherForecast:
-    """Hourly weather forecast plus minimal provider context."""
+    """Normalized hourly weather forecast returned by Open-Meteo."""
 
     points: list[HourlyWeatherPoint]
-    raw: dict[str, Any]
-    provider_timezone: str
 
 
 def _to_float_or_none(value: Any) -> float | None:
@@ -70,6 +67,19 @@ def _resolve_provider_timezone(payload: dict[str, Any]) -> tuple[str, ZoneInfo]:
         raise WeatherProviderError(
             f"Weather provider response contained invalid timezone '{raw_timezone}'"
         ) from exc
+
+
+def _validate_provider_timezone(
+    *,
+    provider_timezone_name: str,
+    requested_timezone_name: str,
+) -> None:
+    """Require the provider to echo back the explicitly requested timezone."""
+
+    if provider_timezone_name != requested_timezone_name:
+        raise WeatherProviderError(
+            "Weather provider response timezone did not match the requested timezone"
+        )
 
 
 def _to_utc_timestamp_or_none(
@@ -114,10 +124,16 @@ def _validate_hourly_units(payload: dict[str, Any]) -> None:
 
 def _extract_hourly_series(
     payload: dict[str, Any],
-) -> tuple[str, list[datetime], dict[str, list[Any]]]:
+    *,
+    requested_timezone_name: str,
+) -> tuple[list[datetime], dict[str, list[Any]]]:
     """Return aligned hourly provider series keyed by the requested fields."""
 
-    timezone_name, provider_time_zone = _resolve_provider_timezone(payload)
+    provider_timezone_name, provider_time_zone = _resolve_provider_timezone(payload)
+    _validate_provider_timezone(
+        provider_timezone_name=provider_timezone_name,
+        requested_timezone_name=requested_timezone_name,
+    )
     hourly = payload.get("hourly")
     if not isinstance(hourly, dict):
         raise WeatherProviderError("Weather provider response was missing hourly data")
@@ -132,7 +148,7 @@ def _extract_hourly_series(
     if any(item is None for item in timestamps):
         raise WeatherProviderError("Weather provider response contained invalid hourly.time values")
 
-    series_data: dict[str, list[Any]] = {"time": raw_time}
+    series_data: dict[str, list[Any]] = {}
     for field in _HOURLY_FIELDS:
         values = hourly.get(field)
         if not isinstance(values, list):
@@ -143,13 +159,20 @@ def _extract_hourly_series(
             )
         series_data[field] = values
 
-    return timezone_name, timestamps, series_data
+    return timestamps, series_data
 
 
-def _select_hourly_points(payload: dict[str, Any]) -> tuple[str, list[HourlyWeatherPoint]]:
+def _select_hourly_points(
+    payload: dict[str, Any],
+    *,
+    requested_timezone_name: str,
+) -> list[HourlyWeatherPoint]:
     """Keep only the current-to-7-day forecast window and normalize each row."""
 
-    timezone_name, timestamps, series_data = _extract_hourly_series(payload)
+    timestamps, series_data = _extract_hourly_series(
+        payload,
+        requested_timezone_name=requested_timezone_name,
+    )
     threshold = datetime.now(tz=UTC) - timedelta(hours=1)
     forecast_window_end = threshold + timedelta(days=7)
     candidate_rows = [
@@ -160,20 +183,16 @@ def _select_hourly_points(payload: dict[str, Any]) -> tuple[str, list[HourlyWeat
     if not candidate_rows:
         raise WeatherProviderError("No hourly record after now-1h")
 
-    return (
-        timezone_name,
-        [
-            HourlyWeatherPoint(
-                raw_time=str(series_data["time"][idx]),
-                time_utc=timestamp,
-                tdb=_to_float_or_none(series_data["temperature_2m"][idx]),
-                rh=_to_float_or_none(series_data["relative_humidity_2m"][idx]),
-                wind=_to_float_or_none(series_data["wind_speed_10m"][idx]),
-                radiation=_to_float_or_none(series_data["direct_normal_irradiance"][idx]),
-            )
-            for idx, timestamp in candidate_rows
-        ],
-    )
+    return [
+        HourlyWeatherPoint(
+            time_utc=timestamp,
+            tdb=_to_float_or_none(series_data["temperature_2m"][idx]),
+            rh=_to_float_or_none(series_data["relative_humidity_2m"][idx]),
+            wind=_to_float_or_none(series_data["wind_speed_10m"][idx]),
+            radiation=_to_float_or_none(series_data["direct_normal_irradiance"][idx]),
+        )
+        for idx, timestamp in candidate_rows
+    ]
 
 
 class OpenMeteoClient:
@@ -199,6 +218,7 @@ class OpenMeteoClient:
         *,
         latitude: float,
         longitude: float,
+        timezone_name: str,
     ) -> WeatherForecast:
         """Fetch and validate the hourly weather forecast needed by the backend."""
 
@@ -207,7 +227,7 @@ class OpenMeteoClient:
             "longitude": longitude,
             "hourly": ",".join(_HOURLY_FIELDS),
             "wind_speed_unit": "ms",
-            "timezone": "GMT",
+            "timezone": timezone_name,
         }
 
         try:
@@ -218,12 +238,8 @@ class OpenMeteoClient:
             raise WeatherProviderError() from exc
 
         _validate_hourly_units(payload)
-        timezone_name, points = _select_hourly_points(payload)
-        return WeatherForecast(
-            points=points,
-            raw=payload,
-            provider_timezone=timezone_name,
-        )
+        points = _select_hourly_points(payload, requested_timezone_name=timezone_name)
+        return WeatherForecast(points=points)
 
     async def aclose(self) -> None:
         """Close the owned HTTP client when the application shuts down."""

--- a/backend/src/sma_extreme_heat_backend/schemas/home.py
+++ b/backend/src/sma_extreme_heat_backend/schemas/home.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import StrEnum
 from typing import ClassVar
 
@@ -78,9 +79,10 @@ class ForecastHeatRisk(BaseModel):
 
 
 class ForecastPoint(BaseModel):
-    """One forecast point with UTC time, explicit inputs, and calculated risk."""
+    """One forecast point with UTC and location-local time plus calculated risk."""
 
-    time_utc: str = Field(min_length=1)
+    time_utc: datetime
+    time_local: datetime
     inputs: ForecastInputs
     heat_risk: ForecastHeatRisk
 

--- a/backend/src/sma_extreme_heat_backend/services/mrt.py
+++ b/backend/src/sma_extreme_heat_backend/services/mrt.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC
 from functools import cache
 from typing import Any
 
@@ -104,25 +103,18 @@ def build_mrt_dataframe(
     longitude: float,
     timezone_name: str,
 ) -> pd.DataFrame:
-    """Build the MRT-enriched half-hourly DataFrame used by the risk service."""
+    """Build the MRT-enriched hourly DataFrame used by the risk service."""
 
     df_weather = _points_to_dataframe(points)
     df_weather = df_weather.set_index("time").sort_index()
     df_weather = df_weather.copy()
-    # Convert provider UTC timestamps into the resolved local timezone before resampling.
+    # The provider window is already trimmed upstream in UTC. From here on we only need the
+    # resolved local timezone so solar geometry is computed against location-local timestamps.
     df_weather.index = df_weather.index.tz_convert(timezone_name)
-
-    now = pd.Timestamp.now(tz=timezone_name) - pd.Timedelta(hours=1)
-    df_weather = df_weather[df_weather.index >= now]
-    if df_weather.empty:
-        raise WeatherProviderError("No hourly record after now-1h")
 
     df_weather = df_weather.dropna(subset=["tdb"])
     if df_weather.empty:
-        raise WeatherProviderError("No hourly record with tdb after now-1h")
-
-    # Interpolate onto a 30-minute grid so forecast charts and current selection share one pipeline.
-    df_weather = df_weather.resample("30min").interpolate()
+        raise WeatherProviderError("No hourly record with tdb in provider forecast window")
 
     site = location.Location(
         latitude,
@@ -177,13 +169,3 @@ def build_mrt_dataframe(
     df_result["tr"] = df_result["tdb"] + df_result["delta_mrt"]
 
     return df_result.loc[:, list(MRT_COLUMNS)].copy()
-
-
-def select_hourly_forecast_rows(df: pd.DataFrame) -> pd.DataFrame:
-    """Keep only rows aligned to UTC hour boundaries for the public forecast."""
-
-    if df.empty:
-        return df.copy()
-
-    utc_index = df.index.tz_convert(UTC)
-    return df.loc[utc_index.minute == 0].copy()

--- a/backend/src/sma_extreme_heat_backend/services/risk_service.py
+++ b/backend/src/sma_extreme_heat_backend/services/risk_service.py
@@ -32,7 +32,6 @@ from sma_extreme_heat_backend.schemas.home import (
 from sma_extreme_heat_backend.services.mrt import (
     build_mrt_dataframe,
     resolve_timezone_name,
-    select_hourly_forecast_rows,
 )
 
 
@@ -92,13 +91,14 @@ class RiskService:
         if cached and cached.expires_at > now:
             return cached.value
 
-        weather = await self.weather_client.fetch_weather_forecast(
-            latitude=payload.latitude,
-            longitude=payload.longitude,
-        )
         timezone_name = resolve_timezone_name(
             latitude=payload.latitude,
             longitude=payload.longitude,
+        )
+        weather = await self.weather_client.fetch_weather_forecast(
+            latitude=payload.latitude,
+            longitude=payload.longitude,
+            timezone_name=timezone_name,
         )
         mrt_df = build_mrt_dataframe(
             points=weather.points,
@@ -106,9 +106,6 @@ class RiskService:
             longitude=payload.longitude,
             timezone_name=timezone_name,
         )
-        hourly_mrt_df = select_hourly_forecast_rows(mrt_df)
-        if hourly_mrt_df.empty:
-            raise WeatherProviderError("No hourly record after 30-minute resample")
 
         # Profiles already flow through the public contract and cache key, but
         # all supported age groups currently use the same pythermalcomfort model path.
@@ -122,7 +119,7 @@ class RiskService:
                     timezone=timezone_name,
                 ),
             ),
-            forecast=self._build_forecast(hourly_mrt_df=hourly_mrt_df, sport=payload.sport),
+            forecast=self._build_forecast(forecast_mrt_df=mrt_df, sport=payload.sport),
         )
 
         self._cache[key] = CacheEntry(value=response, expires_at=now + self.ttl_seconds)
@@ -142,14 +139,16 @@ class RiskService:
     def _build_forecast(
         self,
         *,
-        hourly_mrt_df: pd.DataFrame,
+        forecast_mrt_df: pd.DataFrame,
         sport: str,
     ) -> list[ForecastPoint]:
         """Convert MRT rows into forecast points, using the earliest complete row as current."""
 
-        first_candidate_point = self._first_candidate_forecast_point(hourly_mrt_df=hourly_mrt_df)
+        first_candidate_point = self._first_candidate_forecast_point(
+            forecast_mrt_df=forecast_mrt_df
+        )
         forecast: list[ForecastPoint] = []
-        for timestamp, point in hourly_mrt_df.iterrows():
+        for timestamp, point in forecast_mrt_df.iterrows():
             missing_inputs = self._missing_required_input_fields(point)
             if missing_inputs:
                 # Skip incomplete leading/future rows so `forecast[0]` is always the earliest
@@ -161,11 +160,6 @@ class RiskService:
                 point=point,
                 sport=sport,
             )
-            if not forecast:
-                # The first appended point becomes the canonical current reading for the UI.
-                forecast.append(forecast_point)
-                continue
-
             forecast.append(forecast_point)
 
         if forecast:
@@ -196,12 +190,12 @@ class RiskService:
         return missing_inputs
 
     @staticmethod
-    def _first_candidate_forecast_point(*, hourly_mrt_df: pd.DataFrame) -> pd.Series:
+    def _first_candidate_forecast_point(*, forecast_mrt_df: pd.DataFrame) -> pd.Series:
         """Return the earliest candidate row, used for fallback 422 error details."""
 
-        for _, point in hourly_mrt_df.iterrows():
+        for _, point in forecast_mrt_df.iterrows():
             return point
-        raise WeatherProviderError("No hourly record after 30-minute resample")
+        raise WeatherProviderError("No hourly record after MRT enrichment")
 
     def _missing_input_error_for_point(
         self,
@@ -274,7 +268,8 @@ class RiskService:
         )
 
         return ForecastPoint(
-            time_utc=self._to_time_utc(timestamp),
+            time_utc=timestamp.astimezone(UTC),
+            time_local=timestamp,
             inputs=ForecastInputs(
                 air_temperature_c=float(point.tdb),
                 mean_radiant_temperature_c=float(point.tr),
@@ -285,12 +280,6 @@ class RiskService:
             ),
             heat_risk=ForecastHeatRisk.model_validate(computed.data),
         )
-
-    @staticmethod
-    def _to_time_utc(timestamp: datetime) -> str:
-        """Serialize a timestamp to the API's UTC ISO-8601 format."""
-
-        return timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
     @staticmethod
     def _resolve_model_wind_speed(*, vr: float, sport: str) -> float:

--- a/backend/tests/api/test_home_risk.py
+++ b/backend/tests/api/test_home_risk.py
@@ -43,6 +43,7 @@ class SuccessfulRiskService:
             forecast=[
                 ForecastPoint(
                     time_utc="2026-03-09T00:00:00Z",
+                    time_local="2026-03-09T11:00:00+11:00",
                     inputs=ForecastInputs(
                         air_temperature_c=31.0,
                         mean_radiant_temperature_c=37.25,
@@ -61,6 +62,7 @@ class SuccessfulRiskService:
                 ),
                 ForecastPoint(
                     time_utc="2026-03-09T01:00:00Z",
+                    time_local="2026-03-09T12:00:00+11:00",
                     inputs=ForecastInputs(
                         air_temperature_c=32.0,
                         mean_radiant_temperature_c=38.1,
@@ -140,6 +142,7 @@ def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) 
         "forecast": [
             {
                 "time_utc": "2026-03-09T00:00:00Z",
+                "time_local": "2026-03-09T11:00:00+11:00",
                 "inputs": {
                     "air_temperature_c": 31.0,
                     "mean_radiant_temperature_c": 37.25,
@@ -158,6 +161,7 @@ def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) 
             },
             {
                 "time_utc": "2026-03-09T01:00:00Z",
+                "time_local": "2026-03-09T12:00:00+11:00",
                 "inputs": {
                     "air_temperature_c": 32.0,
                     "mean_radiant_temperature_c": 38.1,

--- a/backend/tests/clients/test_open_meteo.py
+++ b/backend/tests/clients/test_open_meteo.py
@@ -4,12 +4,13 @@ from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import httpx
+import pytest
 
 from sma_extreme_heat_backend.clients.open_meteo import OpenMeteoClient
 from sma_extreme_heat_backend.core.errors import WeatherProviderError
 
 
-def _hourly_time_strings(times: list[datetime], *, timezone_name: str = "GMT") -> list[str]:
+def _hourly_time_strings(times: list[datetime], *, timezone_name: str = "UTC") -> list[str]:
     """Render timestamps using the provider timezone contract."""
 
     provider_time_zone = ZoneInfo(timezone_name)
@@ -30,7 +31,7 @@ def _hourly_payload(
     rh: list[float | None],
     wind: list[float | None],
     radiation: list[float | None],
-    timezone_name: str = "GMT",
+    timezone_name: str = "UTC",
     units_override: dict[str, str] | None = None,
 ) -> dict:
     """Build a minimal Open-Meteo hourly payload for tests."""
@@ -87,6 +88,7 @@ async def test_fetch_weather_forecast_returns_hourly_points_from_now_minus_1h() 
         rh=[80.0, 62.0, 61.0, 60.0],
         wind=[0.9, 1.5, 1.1, 1.0],
         radiation=[0.0, 720.0, 760.0, 780.0],
+        timezone_name="UTC",
     )
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -94,12 +96,16 @@ async def test_fetch_weather_forecast_returns_hourly_points_from_now_minus_1h() 
             "temperature_2m,relative_humidity_2m,wind_speed_10m,direct_normal_irradiance"
         )
         assert request.url.params["wind_speed_unit"] == "ms"
-        assert request.url.params["timezone"] == "GMT"
+        assert request.url.params["timezone"] == "UTC"
         return httpx.Response(status_code=200, json=payload)
 
     client, mock_client = _build_client(handler)
 
-    weather = await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+    weather = await client.fetch_weather_forecast(
+        latitude=-33.847,
+        longitude=151.067,
+        timezone_name="UTC",
+    )
     await mock_client.aclose()
 
     assert [point.time_utc for point in weather.points] == [
@@ -107,44 +113,54 @@ async def test_fetch_weather_forecast_returns_hourly_points_from_now_minus_1h() 
         now + timedelta(hours=1),
         now + timedelta(hours=2),
     ]
-    assert [point.raw_time for point in weather.points] == [
-        now.strftime("%Y-%m-%dT%H:%M"),
-        (now + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M"),
-        (now + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M"),
-    ]
     assert [point.tdb for point in weather.points] == [31.0, 33.0, 34.0]
     assert [point.rh for point in weather.points] == [62.0, 61.0, 60.0]
     assert [point.wind for point in weather.points] == [1.5, 1.1, 1.0]
     assert [point.radiation for point in weather.points] == [720.0, 760.0, 780.0]
-    assert weather.provider_timezone == "GMT"
 
 
-async def test_fetch_weather_forecast_converts_local_hourly_times_back_to_utc() -> None:
-    """Provider-local timestamps should still normalize back to UTC."""
+@pytest.mark.parametrize(
+    ("timezone_name", "utc_minute"),
+    [
+        ("Australia/Adelaide", 30),
+        ("Australia/Eucla", 15),
+        ("Asia/Kathmandu", 15),
+    ],
+)
+async def test_fetch_weather_forecast_converts_local_hourly_times_back_to_utc(
+    timezone_name: str,
+    utc_minute: int,
+) -> None:
+    """Provider-local timestamps should normalize back to UTC instants."""
 
-    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    now = datetime.now(tz=UTC).replace(minute=utc_minute, second=0, microsecond=0)
     payload = _hourly_payload(
         times=[now - timedelta(hours=2), now, now + timedelta(hours=1)],
         tdb=[19.0, 31.0, 33.0],
         rh=[80.0, 62.0, 61.0],
         wind=[0.9, 1.5, 1.1],
         radiation=[0.0, 720.0, 760.0],
-        timezone_name="Australia/Perth",
+        timezone_name=timezone_name,
     )
 
     def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["timezone"] == timezone_name
         return httpx.Response(status_code=200, json=payload)
 
     client, mock_client = _build_client(handler)
 
-    weather = await client.fetch_weather_forecast(latitude=-31.9523, longitude=115.8613)
+    weather = await client.fetch_weather_forecast(
+        latitude=-31.9523,
+        longitude=115.8613,
+        timezone_name=timezone_name,
+    )
     await mock_client.aclose()
 
     assert [point.time_utc for point in weather.points] == [
         now,
         now + timedelta(hours=1),
     ]
-    assert weather.provider_timezone == "Australia/Perth"
+    assert [point.time_utc.minute for point in weather.points] == [utc_minute, utc_minute]
 
 
 async def test_fetch_weather_forecast_rejects_invalid_temperature_unit() -> None:
@@ -166,7 +182,11 @@ async def test_fetch_weather_forecast_rejects_invalid_temperature_unit() -> None
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert "temperature_2m" in str(exc.detail)
     else:
@@ -194,7 +214,11 @@ async def test_fetch_weather_forecast_rejects_invalid_direct_normal_irradiance_u
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert "direct_normal_irradiance" in str(exc.detail)
     else:
@@ -222,7 +246,11 @@ async def test_fetch_weather_forecast_rejects_missing_timezone_metadata() -> Non
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert exc.detail == "Weather provider response was missing timezone"
     else:
@@ -250,11 +278,50 @@ async def test_fetch_weather_forecast_rejects_invalid_timezone_metadata() -> Non
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert "invalid timezone" in str(exc.detail)
     else:
         raise AssertionError("Expected WeatherProviderError for invalid timezone metadata")
+    finally:
+        await mock_client.aclose()
+
+
+async def test_fetch_weather_forecast_rejects_provider_timezone_mismatch() -> None:
+    """Provider timezone metadata must match the explicitly requested timezone."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    payload = _hourly_payload(
+        times=[now],
+        tdb=[31.0],
+        rh=[62.0],
+        wind=[1.5],
+        radiation=[720.0],
+        timezone_name="Australia/Perth",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json=payload)
+
+    client, mock_client = _build_client(handler)
+
+    try:
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="Australia/Sydney",
+        )
+    except WeatherProviderError as exc:
+        assert (
+            exc.detail
+            == "Weather provider response timezone did not match the requested timezone"
+        )
+    else:
+        raise AssertionError("Expected WeatherProviderError for timezone mismatch")
     finally:
         await mock_client.aclose()
 
@@ -277,7 +344,11 @@ async def test_fetch_weather_forecast_raises_when_no_hourly_record_after_now_min
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert exc.detail == "No hourly record after now-1h"
     else:
@@ -292,7 +363,7 @@ async def test_fetch_weather_forecast_rejects_invalid_hourly_time_value() -> Non
     """Malformed hourly timestamps should fail validation."""
 
     payload = {
-        "timezone": "GMT",
+        "timezone": "UTC",
         "hourly_units": {
             "temperature_2m": "°C",
             "relative_humidity_2m": "%",
@@ -314,7 +385,11 @@ async def test_fetch_weather_forecast_rejects_invalid_hourly_time_value() -> Non
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert exc.detail == "Weather provider response contained invalid hourly.time values"
     else:
@@ -343,7 +418,11 @@ async def test_fetch_weather_forecast_rejects_length_mismatch_for_direct_normal_
     client, mock_client = _build_client(handler)
 
     try:
-        await client.fetch_weather_forecast(latitude=-33.847, longitude=151.067)
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
     except WeatherProviderError as exc:
         assert exc.detail == (
             "Weather provider response length mismatch for hourly.direct_normal_irradiance"

--- a/backend/tests/services/test_mrt.py
+++ b/backend/tests/services/test_mrt.py
@@ -9,15 +9,14 @@ from sma_extreme_heat_backend.clients.open_meteo import HourlyWeatherPoint
 from sma_extreme_heat_backend.services.mrt import (
     build_mrt_dataframe,
     resolve_timezone_name,
-    select_hourly_forecast_rows,
 )
 
 
-def _next_utc_hour(hour: int) -> datetime:
-    """Return the next UTC hour used to keep MRT tests stable."""
+def _next_utc_time(hour: int, minute: int = 0) -> datetime:
+    """Return the next UTC timestamp used to keep MRT tests stable."""
 
     now = datetime.now(tz=UTC)
-    candidate = now.replace(hour=hour, minute=0, second=0, microsecond=0)
+    candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
     if candidate <= now:
         candidate += timedelta(days=1)
     return candidate
@@ -31,7 +30,6 @@ def _build_points(*, start: datetime, radiation: list[float]) -> list[HourlyWeat
         timestamp = start + timedelta(hours=offset)
         points.append(
             HourlyWeatherPoint(
-                raw_time=timestamp.strftime("%Y-%m-%dT%H:%M"),
                 time_utc=timestamp,
                 tdb=30.0 + offset,
                 rh=55.0 + offset,
@@ -52,7 +50,7 @@ def test_build_mrt_dataframe_daytime_produces_positive_delta_mrt_and_higher_tr()
     """Daytime radiation should increase MRT above dry-bulb air temperature."""
 
     points = _build_points(
-        start=_next_utc_hour(12),
+        start=_next_utc_time(12),
         radiation=[800.0, 850.0, 900.0],
     )
 
@@ -62,20 +60,18 @@ def test_build_mrt_dataframe_daytime_produces_positive_delta_mrt_and_higher_tr()
         longitude=0.0,
         timezone_name="UTC",
     )
-    hourly_result = select_hourly_forecast_rows(result)
 
-    assert any(timestamp.minute == 30 for timestamp in result.index)
-    assert all(timestamp.minute == 0 for timestamp in hourly_result.index.tz_convert(UTC))
-    assert (hourly_result["delta_mrt"] > 0).all()
-    assert (hourly_result["tr"] > hourly_result["tdb"]).all()
-    assert hourly_result["radiation"].tolist() == [800.0, 850.0, 900.0]
+    assert set(result.index.minute) == {0}
+    assert (result["delta_mrt"] > 0).all()
+    assert (result["tr"] > result["tdb"]).all()
+    assert result["radiation"].tolist() == [800.0, 850.0, 900.0]
 
 
 def test_build_mrt_dataframe_nighttime_clamps_elevation_and_keeps_delta_mrt_near_zero() -> None:
     """Nighttime inputs should clamp solar elevation to zero and avoid extra MRT load."""
 
     points = _build_points(
-        start=_next_utc_hour(0),
+        start=_next_utc_time(0),
         radiation=[0.0, 0.0, 0.0],
     )
 
@@ -85,19 +81,18 @@ def test_build_mrt_dataframe_nighttime_clamps_elevation_and_keeps_delta_mrt_near
         longitude=0.0,
         timezone_name="UTC",
     )
-    hourly_result = select_hourly_forecast_rows(result)
 
-    assert hourly_result["elevation"].tolist() == [0.0, 0.0, 0.0]
-    assert hourly_result["delta_mrt"].abs().max() == pytest.approx(0.0, abs=1e-6)
-    assert (hourly_result["tr"] <= hourly_result["tdb"] + 1e-6).all()
-    assert any(timestamp.minute == 30 for timestamp in result.index)
+    assert result["elevation"].tolist() == [0.0, 0.0, 0.0]
+    assert result["delta_mrt"].abs().max() == pytest.approx(0.0, abs=1e-6)
+    assert (result["tr"] <= result["tdb"] + 1e-6).all()
+    assert set(result.index.minute) == {0}
 
 
-def test_build_mrt_dataframe_preserves_hourly_selection_for_half_hour_timezone() -> None:
-    """UTC-hour filtering should still work for half-hour local timezones."""
+def test_build_mrt_dataframe_preserves_hourly_local_time_for_half_hour_timezone() -> None:
+    """Provider-native Adelaide hourly points should stay on local hour boundaries."""
 
     points = _build_points(
-        start=_next_utc_hour(12),
+        start=_next_utc_time(12, 30),
         radiation=[800.0, 850.0, 900.0],
     )
 
@@ -107,12 +102,30 @@ def test_build_mrt_dataframe_preserves_hourly_selection_for_half_hour_timezone()
         longitude=138.6007,
         timezone_name="Australia/Adelaide",
     )
-    hourly_result = select_hourly_forecast_rows(result)
 
-    assert set(result.index.minute) == {0, 30}
-    assert set(hourly_result.index.minute) == {30}
-    assert all(timestamp.minute == 0 for timestamp in hourly_result.index.tz_convert(UTC))
-    assert hourly_result["radiation"].tolist() == [800.0, 850.0, 900.0]
+    assert set(result.index.minute) == {0}
+    assert set(result.index.tz_convert(UTC).minute) == {30}
+    assert result["radiation"].tolist() == [800.0, 850.0, 900.0]
+
+
+def test_build_mrt_dataframe_preserves_hourly_local_time_for_quarter_hour_timezone() -> None:
+    """Provider-native Eucla hourly points should stay on local hour boundaries."""
+
+    points = _build_points(
+        start=_next_utc_time(15, 15),
+        radiation=[800.0, 850.0, 900.0],
+    )
+
+    result = build_mrt_dataframe(
+        points=points,
+        latitude=-31.721,
+        longitude=128.883,
+        timezone_name="Australia/Eucla",
+    )
+
+    assert set(result.index.minute) == {0}
+    assert set(result.index.tz_convert(UTC).minute) == {15}
+    assert result["radiation"].tolist() == [800.0, 850.0, 900.0]
 
 
 def test_build_mrt_dataframe_logs_structured_warning_for_negative_delta_mrt(
@@ -122,7 +135,7 @@ def test_build_mrt_dataframe_logs_structured_warning_for_negative_delta_mrt(
     """Negative MRT deltas should be logged with structured diagnostics."""
 
     points = _build_points(
-        start=_next_utc_hour(12),
+        start=_next_utc_time(12),
         radiation=[800.0, 850.0, 900.0],
     )
 

--- a/backend/tests/services/test_risk_service.py
+++ b/backend/tests/services/test_risk_service.py
@@ -25,14 +25,15 @@ class FakeWeatherClient:
         *,
         expected_latitude: float | None = -33.847,
         expected_longitude: float | None = 151.067,
+        expected_timezone_name: str | None = "Australia/Sydney",
     ) -> None:
         self.calls = 0
         self.expected_latitude = expected_latitude
         self.expected_longitude = expected_longitude
+        self.expected_timezone_name = expected_timezone_name
         base_time = datetime(2026, 3, 9, 0, 0, tzinfo=UTC)
         self.points = [
             HourlyWeatherPoint(
-                raw_time=(base_time + timedelta(hours=offset)).strftime("%Y-%m-%dT%H:%M"),
                 time_utc=base_time + timedelta(hours=offset),
                 tdb=31.0 + offset,
                 rh=62.0 + offset,
@@ -42,7 +43,13 @@ class FakeWeatherClient:
             for offset in range(3)
         ]
 
-    async def fetch_weather_forecast(self, *, latitude: float, longitude: float) -> WeatherForecast:
+    async def fetch_weather_forecast(
+        self,
+        *,
+        latitude: float,
+        longitude: float,
+        timezone_name: str,
+    ) -> WeatherForecast:
         """Return the deterministic forecast and track request counts."""
 
         self.calls += 1
@@ -50,11 +57,9 @@ class FakeWeatherClient:
             assert latitude == self.expected_latitude
         if self.expected_longitude is not None:
             assert longitude == self.expected_longitude
-        return WeatherForecast(
-            points=self.points,
-            raw={"provider": "open-meteo", "timezone": "GMT"},
-            provider_timezone="GMT",
-        )
+        if self.expected_timezone_name is not None:
+            assert timezone_name == self.expected_timezone_name
+        return WeatherForecast(points=self.points)
 
     async def aclose(self) -> None:
         """Match the real client shutdown interface."""
@@ -91,6 +96,7 @@ class FakeCalculator:
 def _build_mrt_dataframe(
     *,
     timezone_name: str = "Australia/Sydney",
+    utc_start: str = "2026-03-09T00:00:00Z",
     wind_start: float = 1.5,
     tr_offset: float = 6.25,
     current_missing: set[str] | None = None,
@@ -101,7 +107,7 @@ def _build_mrt_dataframe(
     current_missing = current_missing or set()
     future_missing_by_row = future_missing_by_row or {}
     index_utc = pd.date_range(
-        start="2026-03-09T00:00:00Z",
+        start=utc_start,
         periods=3,
         freq="1h",
     )
@@ -200,9 +206,10 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
         "t_extreme": 39.2,
         "recommendation": "Increase hydration & modify clothing",
     }
-    assert first.model_dump()["forecast"] == [
+    assert first.model_dump(mode="json")["forecast"] == [
         {
             "time_utc": "2026-03-09T00:00:00Z",
+            "time_local": "2026-03-09T11:00:00+11:00",
             "inputs": {
                 "air_temperature_c": 31.0,
                 "mean_radiant_temperature_c": 37.25,
@@ -221,6 +228,7 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
         },
         {
             "time_utc": "2026-03-09T01:00:00Z",
+            "time_local": "2026-03-09T12:00:00+11:00",
             "inputs": {
                 "air_temperature_c": 32.0,
                 "mean_radiant_temperature_c": 38.25,
@@ -239,6 +247,7 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
         },
         {
             "time_utc": "2026-03-09T02:00:00Z",
+            "time_local": "2026-03-09T13:00:00+11:00",
             "inputs": {
                 "air_temperature_c": 33.0,
                 "mean_radiant_temperature_c": 39.25,
@@ -291,6 +300,50 @@ async def test_risk_service_cache_key_changes_with_coordinates(
 
     assert weather_client.calls == 2
     assert calculator.calls == 6
+
+
+async def test_risk_service_returns_local_hourly_times_for_quarter_hour_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forecast points should expose local hourly labels for quarter-hour timezones."""
+
+    _install_mrt_pipeline(
+        monkeypatch,
+        df=_build_mrt_dataframe(
+            timezone_name="Australia/Eucla",
+            utc_start="2026-03-09T00:15:00Z",
+        ),
+        timezone_name="Australia/Eucla",
+    )
+    service = RiskService(
+        weather_client=FakeWeatherClient(
+            expected_latitude=-31.721,
+            expected_longitude=128.883,
+            expected_timezone_name="Australia/Eucla",
+        ),
+        calculator=FakeCalculator(),
+        ttl_seconds=600,
+    )
+
+    response = await service.calculate_home_risk(
+        RiskRequest(
+            sport="SOCCER",
+            latitude=-31.721,
+            longitude=128.883,
+            profile="ADULT",
+        )
+    )
+
+    assert [point.model_dump(mode="json")["time_utc"] for point in response.forecast] == [
+        "2026-03-09T00:15:00Z",
+        "2026-03-09T01:15:00Z",
+        "2026-03-09T02:15:00Z",
+    ]
+    assert [point.model_dump(mode="json")["time_local"] for point in response.forecast] == [
+        "2026-03-09T09:00:00+08:45",
+        "2026-03-09T10:00:00+08:45",
+        "2026-03-09T11:00:00+08:45",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -462,7 +515,7 @@ async def test_risk_service_skips_future_points_with_missing_inputs(
     )
 
     assert calculator.calls == 2
-    assert [point.time_utc for point in response.forecast] == [
+    assert [point.model_dump(mode="json")["time_utc"] for point in response.forecast] == [
         "2026-03-09T00:00:00Z",
         "2026-03-09T02:00:00Z",
     ]
@@ -491,7 +544,7 @@ async def test_risk_service_skips_incomplete_leading_rows_and_uses_next_complete
     )
 
     assert calculator.calls == 2
-    assert [point.time_utc for point in response.forecast] == [
+    assert [point.model_dump(mode="json")["time_utc"] for point in response.forecast] == [
         "2026-03-09T01:00:00Z",
         "2026-03-09T02:00:00Z",
     ]

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -91,7 +91,7 @@
 - Risk API failures must be surfaced and keep the last valid result.
 - On successful fetch, update `sport` and `loc` query params with replace history.
 - Persist to localStorage only for direct visits (not shared links).
-- Forecast time display uses selected location timezone first; browser timezone is fallback only.
+- Forecast time display uses backend-provided `time_local` for point labels/grouping and `request.location.timezone` for date formatting.
 
 ## Testing Expectations
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -76,7 +76,7 @@ Import rules:
 - Location search uses Mapbox Search Box `suggest`; selecting a suggestion triggers Mapbox `retrieve` in frontend to resolve coordinates.
 - Prefilled location labels restored from shared URL (`loc`) or local persistence automatically attempt `suggest + retrieve` once using exact normalized label matching.
 - Risk API request sends `sport + latitude + longitude + profile` (no Mapbox identifiers).
-- Risk API response returns a non-empty `forecast[]` plus a nested `request` block containing `sport`, `profile`, and `location`; backend defines `forecast[0]` as the earliest complete forecast point, and frontend derives the current risk from that point while grouping forecast days in the selected location timezone when available, otherwise browser local timezone.
+- Risk API response returns a non-empty `forecast[]` plus a nested `request` block containing `sport`, `profile`, and `location`; backend defines `forecast[0]` as the earliest complete forecast point, each forecast row includes both `time_utc` and `time_local`, and frontend derives the current risk from `forecast[0]` while grouping chart days from `time_local`.
 - Risk is fetched automatically when:
   - a location suggestion is selected (manual or auto-resolved) and coordinates are resolved, and
   - the sport changes, and
@@ -85,8 +85,8 @@ Import rules:
 - After a successful fetch:
   - URL query params update (`profile`, `sport`, `loc`) and
   - the last selection is persisted to localStorage only for direct visits (not shared links).
-- Dates are formatted in the selected location timezone when available, otherwise browser local timezone.
-- API time contract: if datetime fields are introduced in request/response payloads, they must use ISO-8601 UTC format (`...Z`).
+- Dates are formatted in the selected location timezone supplied by the backend.
+- API time contract: forecast responses must carry `time_utc` as ISO-8601 UTC (`...Z`) and `time_local` as ISO-8601 local time with an explicit offset.
 - The Home filters expose a Profile select above Location and Sport.
 - Public profile values are `ADULT`, `UNDER_10`, `AGE_10_13`, and `AGE_14_17`.
 - The current profile is sent to the backend and restored from shared URLs or local persistence.

--- a/frontend/src/api/heatRisk.test.ts
+++ b/frontend/src/api/heatRisk.test.ts
@@ -39,6 +39,7 @@ describe("isHeatRiskApiResponse", () => {
         forecast: [
           {
             time_utc: "2026-03-09T00:00:00Z",
+            time_local: "2026-03-09T11:00:00+11:00",
             inputs: {
               air_temperature_c: 31,
               mean_radiant_temperature_c: 37.25,
@@ -71,6 +72,43 @@ describe("isHeatRiskApiResponse", () => {
           latitude: -33.847,
           longitude: 151.067,
           timezone: "Australia/Sydney",
+        },
+        forecast: [
+          {
+            time_utc: "2026-03-09T00:00:00Z",
+            time_local: "2026-03-09T11:00:00+11:00",
+            inputs: {
+              air_temperature_c: 31,
+              mean_radiant_temperature_c: 37.25,
+              relative_humidity_pct: 62,
+              wind_speed_10m_ms: 1.5,
+              wind_speed_effective_ms: 1.02,
+              direct_normal_irradiance_wm2: 700,
+            },
+            heat_risk: {
+              risk_level_interpolated: 1.94,
+              t_medium: 34.5,
+              t_high: 37.1,
+              t_extreme: 39.2,
+              recommendation: "Increase hydration & modify clothing",
+            },
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects forecast points without time_local", () => {
+    expect(
+      isHeatRiskApiResponse({
+        request: {
+          sport: "SOCCER",
+          profile: "ADULT",
+          location: {
+            latitude: -33.847,
+            longitude: 151.067,
+            timezone: "Australia/Sydney",
+          },
         },
         forecast: [
           {

--- a/frontend/src/api/heatRisk.ts
+++ b/frontend/src/api/heatRisk.ts
@@ -5,6 +5,7 @@ import {
   isHeatRiskProfile,
   type HeatRiskProfile,
 } from "@/domain/heatRiskProfile";
+import { parseOffsetIsoDateTime } from "@/lib/offsetIsoDateTime";
 
 export interface HeatRiskRequest {
   sport: SportType;
@@ -32,6 +33,7 @@ export interface ForecastInputsApiData {
 
 export interface ForecastApiPoint {
   time_utc: string;
+  time_local: string;
   inputs: ForecastInputsApiData;
   heat_risk: HeatRiskApiData;
 }
@@ -96,6 +98,10 @@ function isValidIsoDateTime(value: unknown): value is string {
   );
 }
 
+function isValidOffsetIsoDateTime(value: unknown): value is string {
+  return parseOffsetIsoDateTime(value) !== null;
+}
+
 function isHeatRiskApiData(value: unknown): value is HeatRiskApiData {
   if (!isRecord(value)) {
     return false;
@@ -134,6 +140,7 @@ function isForecastApiPoint(value: unknown): value is ForecastApiPoint {
 
   return (
     isValidIsoDateTime(value.time_utc) &&
+    isValidOffsetIsoDateTime(value.time_local) &&
     isForecastInputsApiData(value.inputs) &&
     isHeatRiskApiData(value.heat_risk)
   );

--- a/frontend/src/hooks/useHomeHeatRisk.ts
+++ b/frontend/src/hooks/useHomeHeatRisk.ts
@@ -70,7 +70,7 @@ function toCalculatedHeatRisk(data: HeatRiskApiResponse): {
   return {
     risk,
     riskLevel: toRiskLevel(risk.riskLevelInterpolated),
-    forecast: toForecastDays(data.forecast, meta.timeZone),
+    forecast: toForecastDays(data.forecast),
     meta,
   };
 }

--- a/frontend/src/lib/formatDate.ts
+++ b/frontend/src/lib/formatDate.ts
@@ -7,14 +7,6 @@ interface WeekdayFormatOptions extends DateFormatOptions {
   weekday?: "long" | "short";
 }
 
-function getBrowserTimeZone(): string | undefined {
-  if (typeof Intl === "undefined") {
-    return undefined;
-  }
-
-  return Intl.DateTimeFormat().resolvedOptions().timeZone;
-}
-
 function formatWithIntl(
   date: string,
   locale: string,
@@ -34,14 +26,13 @@ function formatWithIntl(
 }
 
 /**
- * Formats ISO dates into short, AU-style labels in browser local time by default.
+ * Formats ISO dates into short, AU-style labels, optionally pinned to a specific timezone.
  */
 export function formatDateLabel(
   date: string,
   options?: DateFormatOptions,
 ): string {
   const locale = options?.locale ?? "en-AU";
-  const timeZone = options?.timeZone ?? getBrowserTimeZone();
 
   return formatWithIntl(
     date,
@@ -51,19 +42,18 @@ export function formatDateLabel(
       day: "2-digit",
       month: "short",
     },
-    timeZone,
+    options?.timeZone,
   );
 }
 
 /**
- * Formats ISO dates into weekday labels in browser local time by default.
+ * Formats ISO dates into weekday labels, optionally pinned to a specific timezone.
  */
 export function formatWeekdayLabel(
   date: string,
   options?: WeekdayFormatOptions,
 ): string {
   const locale = options?.locale ?? "en-AU";
-  const timeZone = options?.timeZone ?? getBrowserTimeZone();
 
   return formatWithIntl(
     date,
@@ -71,6 +61,6 @@ export function formatWeekdayLabel(
     {
       weekday: options?.weekday ?? "long",
     },
-    timeZone,
+    options?.timeZone,
   );
 }

--- a/frontend/src/lib/homeRisk.test.ts
+++ b/frontend/src/lib/homeRisk.test.ts
@@ -37,6 +37,7 @@ describe("getCurrentForecastPoint", () => {
         forecast: [
           {
             time_utc: "2026-03-09T01:00:00Z",
+            time_local: "2026-03-09T12:00:00+11:00",
             inputs: {
               air_temperature_c: 31,
               mean_radiant_temperature_c: 37,
@@ -55,6 +56,7 @@ describe("getCurrentForecastPoint", () => {
           },
           {
             time_utc: "2026-03-09T02:00:00Z",
+            time_local: "2026-03-09T13:00:00+11:00",
             inputs: {
               air_temperature_c: 32,
               mean_radiant_temperature_c: 38,
@@ -83,88 +85,11 @@ describe("getCurrentForecastPoint", () => {
 });
 
 describe("toForecastDays", () => {
-  it("groups forecast points using the selected location timezone", () => {
-    const forecastDays = toForecastDays(
-      [
-        {
-          time_utc: "2026-03-09T15:00:00Z",
-          inputs: {
-            air_temperature_c: 30,
-            mean_radiant_temperature_c: 35,
-            relative_humidity_pct: 60,
-            wind_speed_10m_ms: 1.2,
-            wind_speed_effective_ms: 1.0,
-            direct_normal_irradiance_wm2: 650,
-          },
-          heat_risk: {
-            risk_level_interpolated: 0.8,
-            t_medium: 34.5,
-            t_high: 37.1,
-            t_extreme: 39.2,
-            recommendation: "Hydrate",
-          },
-        },
-        {
-          time_utc: "2026-03-09T16:00:00Z",
-          inputs: {
-            air_temperature_c: 31,
-            mean_radiant_temperature_c: 36,
-            relative_humidity_pct: 59,
-            wind_speed_10m_ms: 1.3,
-            wind_speed_effective_ms: 1.1,
-            direct_normal_irradiance_wm2: 670,
-          },
-          heat_risk: {
-            risk_level_interpolated: 1.2,
-            t_medium: 34.5,
-            t_high: 37.1,
-            t_extreme: 39.2,
-            recommendation: "Hydrate",
-          },
-        },
-        {
-          time_utc: "2026-03-09T17:00:00Z",
-          inputs: {
-            air_temperature_c: 32,
-            mean_radiant_temperature_c: 37,
-            relative_humidity_pct: 58,
-            wind_speed_10m_ms: 1.4,
-            wind_speed_effective_ms: 1.2,
-            direct_normal_irradiance_wm2: 690,
-          },
-          heat_risk: {
-            risk_level_interpolated: 1.4,
-            t_medium: 34.5,
-            t_high: 37.1,
-            t_extreme: 39.2,
-            recommendation: "Hydrate",
-          },
-        },
-      ],
-      "Australia/Eucla",
-    );
-
-    expect(forecastDays).toEqual([
-      {
-        date: "2026-03-09T15:00:00Z",
-        risk: "low",
-        points: [{ time: "23:45", value: 0.8 }],
-      },
-      {
-        date: "2026-03-09T16:00:00Z",
-        risk: "moderate",
-        points: [
-          { time: "00:45", value: 1.2 },
-          { time: "01:45", value: 1.4 },
-        ],
-      },
-    ]);
-  });
-
-  it("falls back to the browser timezone when the location timezone is missing", () => {
+  it("groups forecast points using time_local instead of browser-local conversions", () => {
     const forecastDays = toForecastDays([
       {
-        time_utc: "2026-03-09T00:00:00Z",
+        time_utc: "2026-03-09T15:15:00Z",
+        time_local: "2026-03-10T00:00:00+08:45",
         inputs: {
           air_temperature_c: 30,
           mean_radiant_temperature_c: 35,
@@ -181,9 +106,82 @@ describe("toForecastDays", () => {
           recommendation: "Hydrate",
         },
       },
+      {
+        time_utc: "2026-03-09T16:15:00Z",
+        time_local: "2026-03-10T01:00:00+08:45",
+        inputs: {
+          air_temperature_c: 31,
+          mean_radiant_temperature_c: 36,
+          relative_humidity_pct: 59,
+          wind_speed_10m_ms: 1.3,
+          wind_speed_effective_ms: 1.1,
+          direct_normal_irradiance_wm2: 670,
+        },
+        heat_risk: {
+          risk_level_interpolated: 1.2,
+          t_medium: 34.5,
+          t_high: 37.1,
+          t_extreme: 39.2,
+          recommendation: "Hydrate",
+        },
+      },
+      {
+        time_utc: "2026-03-09T17:15:00Z",
+        time_local: "2026-03-10T02:00:00+08:45",
+        inputs: {
+          air_temperature_c: 32,
+          mean_radiant_temperature_c: 37,
+          relative_humidity_pct: 58,
+          wind_speed_10m_ms: 1.4,
+          wind_speed_effective_ms: 1.2,
+          direct_normal_irradiance_wm2: 690,
+        },
+        heat_risk: {
+          risk_level_interpolated: 1.4,
+          t_medium: 34.5,
+          t_high: 37.1,
+          t_extreme: 39.2,
+          recommendation: "Hydrate",
+        },
+      },
     ]);
 
-    expect(forecastDays).toHaveLength(1);
-    expect(forecastDays[0]?.points[0]?.time).toMatch(/^\d{2}:\d{2}$/);
+    expect(forecastDays).toEqual([
+      {
+        date: "2026-03-10T00:00:00+08:45",
+        risk: "moderate",
+        points: [
+          { time: "00:00", value: 0.8 },
+          { time: "01:00", value: 1.2 },
+          { time: "02:00", value: 1.4 },
+        ],
+      },
+    ]);
+  });
+
+  it("throws when a forecast point contains an invalid time_local value", () => {
+    expect(() =>
+      toForecastDays([
+        {
+          time_utc: "2026-03-09T00:00:00Z",
+          time_local: "not-a-local-time",
+          inputs: {
+            air_temperature_c: 30,
+            mean_radiant_temperature_c: 35,
+            relative_humidity_pct: 60,
+            wind_speed_10m_ms: 1.2,
+            wind_speed_effective_ms: 1.0,
+            direct_normal_irradiance_wm2: 650,
+          },
+          heat_risk: {
+            risk_level_interpolated: 0.8,
+            t_medium: 34.5,
+            t_high: 37.1,
+            t_extreme: 39.2,
+            recommendation: "Hydrate",
+          },
+        },
+      ]),
+    ).toThrow("invalid time_local");
   });
 });

--- a/frontend/src/lib/homeRisk.ts
+++ b/frontend/src/lib/homeRisk.ts
@@ -7,6 +7,7 @@ import type {
 import type { ForecastDay, HeatRisk } from "@/domain/risk";
 import { toRiskLevel } from "@/domain/risk";
 import { toCoordinatesOrNull } from "@/lib/coordinates";
+import { parseOffsetIsoDateTime } from "@/lib/offsetIsoDateTime";
 
 export interface HeatRiskMeta {
   latitude?: number;
@@ -68,50 +69,14 @@ export function toHeatRiskMeta(location: HeatRiskApiLocation): HeatRiskMeta {
   };
 }
 
-function getBrowserTimeZone(): string | undefined {
-  if (typeof Intl === "undefined") {
-    return undefined;
-  }
-
-  return Intl.DateTimeFormat().resolvedOptions().timeZone;
-}
-
-function formatDateParts(
-  date: Date,
-  timeZone?: string,
-): Record<"year" | "month" | "day" | "hour" | "minute", string> {
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZone,
-  });
-  const parts = formatter.formatToParts(date);
-
-  return {
-    year: parts.find((part) => part.type === "year")?.value ?? "",
-    month: parts.find((part) => part.type === "month")?.value ?? "",
-    day: parts.find((part) => part.type === "day")?.value ?? "",
-    hour: parts.find((part) => part.type === "hour")?.value ?? "",
-    minute: parts.find((part) => part.type === "minute")?.value ?? "",
-  };
-}
-
 /**
  * Groups forecast points into location-local daily chart data for the UI.
  */
-export function toForecastDays(
-  points: ForecastApiPoint[],
-  timeZone?: string,
-): ForecastDay[] {
+export function toForecastDays(points: ForecastApiPoint[]): ForecastDay[] {
   if (points.length === 0) {
     return [];
   }
 
-  const resolvedTimeZone = timeZone ?? getBrowserTimeZone();
   const groupedDays = new Map<
     string,
     {
@@ -122,25 +87,24 @@ export function toForecastDays(
   >();
 
   for (const point of points) {
-    const parsedDate = new Date(point.time_utc);
+    const localDateTimeParts = parseOffsetIsoDateTime(point.time_local);
 
-    if (Number.isNaN(parsedDate.getTime())) {
-      continue;
+    if (!localDateTimeParts) {
+      throw new Error(
+        "Heat-risk forecast point contained an invalid time_local value.",
+      );
     }
 
-    const dateParts = formatDateParts(parsedDate, resolvedTimeZone);
-    const dateKey = `${dateParts.year}-${dateParts.month}-${dateParts.day}`;
-    const timeLabel = `${dateParts.hour}:${dateParts.minute}`;
     const pointRisk = point.heat_risk.risk_level_interpolated;
-    const existingDay = groupedDays.get(dateKey);
+    const existingDay = groupedDays.get(localDateTimeParts.dateKey);
 
     if (!existingDay) {
-      groupedDays.set(dateKey, {
-        date: point.time_utc,
+      groupedDays.set(localDateTimeParts.dateKey, {
+        date: point.time_local,
         maxRisk: pointRisk,
         points: [
           {
-            time: timeLabel,
+            time: localDateTimeParts.timeLabel,
             value: pointRisk,
           },
         ],
@@ -150,7 +114,7 @@ export function toForecastDays(
 
     existingDay.maxRisk = Math.max(existingDay.maxRisk, pointRisk);
     existingDay.points.push({
-      time: timeLabel,
+      time: localDateTimeParts.timeLabel,
       value: pointRisk,
     });
   }

--- a/frontend/src/lib/offsetIsoDateTime.test.ts
+++ b/frontend/src/lib/offsetIsoDateTime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { parseOffsetIsoDateTime } from "@/lib/offsetIsoDateTime";
+
+describe("parseOffsetIsoDateTime", () => {
+  it("returns the local date key and time label for valid offset ISO datetimes", () => {
+    expect(parseOffsetIsoDateTime("2026-03-10T00:00:00+08:45")).toEqual({
+      dateKey: "2026-03-10",
+      timeLabel: "00:00",
+    });
+  });
+
+  it("rejects values without an explicit numeric offset", () => {
+    expect(parseOffsetIsoDateTime("2026-03-10T00:00:00Z")).toBeNull();
+    expect(parseOffsetIsoDateTime("not-a-local-time")).toBeNull();
+  });
+});

--- a/frontend/src/lib/offsetIsoDateTime.ts
+++ b/frontend/src/lib/offsetIsoDateTime.ts
@@ -1,0 +1,31 @@
+const OFFSET_ISO_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::\d{2}(?:\.\d+)?)?([+-]\d{2}:\d{2})$/;
+
+export interface OffsetIsoDateTimeParts {
+  dateKey: string;
+  timeLabel: string;
+}
+
+/**
+ * Parses an ISO-8601 datetime string with an explicit numeric offset.
+ */
+export function parseOffsetIsoDateTime(
+  value: unknown,
+): OffsetIsoDateTimeParts | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  const match = OFFSET_ISO_DATE_TIME_PATTERN.exec(value);
+
+  if (!match || Number.isNaN(Date.parse(value))) {
+    return null;
+  }
+
+  const [, year, month, day, hour, minute] = match;
+
+  return {
+    dateKey: `${year}-${month}-${day}`,
+    timeLabel: `${hour}:${minute}`,
+  };
+}


### PR DESCRIPTION
Fix forecast time handling for non-hour-offset timezones by switching the
provider request and frontend display flow to location-local hourly points.
e.g. Time zone in Eucla WA (GMT+8:45)

## What changed

- Backend now resolves the request location to an explicit IANA timezone
  and calls Open-Meteo with that timezone instead of `GMT`.
- Backend keeps UTC as the canonical internal instant, but now returns both
  `time_utc` and `time_local` in each forecast point.
- MRT processing now stays on provider-native hourly points and no longer
  uses the old 30-minute resampling path.
- Frontend now requires `time_local` and groups/displays forecast points
  from `time_local` instead of deriving local labels from `time_utc` in
  the browser.
- Frontend `time_local` parsing/validation now uses one shared helper.

## Previous flow

1. Request Open-Meteo with `timezone=GMT`
2. Receive hourly points on UTC hour boundaries
3. Convert to local time in backend for MRT
4. Resample to 30-minute local grid
5. Filter back to UTC-hour rows for API output
6. Return `time_utc` only
7. Frontend converts `time_utc` to local labels in the browser

## New flow

1. Resolve request coordinates to an IANA timezone
2. Request Open-Meteo with that explicit timezone
3. Receive provider-local hourly points aligned to local hour boundaries
4. Parse provider-local timestamps into UTC for backend processing
5. Convert back to local time for MRT calculations
6. Return both `time_utc` and `time_local`
7. Frontend groups and displays forecast points directly from `time_local`

## Why

This removes the old mixed UTC/local conversion path that caused incorrect
forecast labels for `:30`, `:45`, and `:15` offset timezones.

BREAKING CHANGE: forecast API points now require `time_local`.
BREAKING CHANGE: clients must use `time_local` for forecast grouping and display.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Forecast points now include local time alongside UTC time for improved timezone context.
  * Enhanced timezone support using standard IANA timezone identifiers.
  * Forecast granularity adjusted to hourly intervals.

* **API Updates**
  * Updated response structure with refined forecast point format and request context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->