### PR TITLE
Align heat risk contract and frontend score display with pythermalcomfort 3.9.2

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -16,14 +16,13 @@
 - Model inputs are `tdb`, `tr`, `rh`, `vr`, `sport`.
 - Compute `tr` from the MRT pipeline, not by setting `tr = tdb`.
 - Convert Open-Meteo `wind_speed_10m` to 1.1 m with `pythermalcomfort.utils.scale_wind_speed_log(..., round_output=True)` before model call.
-- Apply a sport wind-speed floor after scaling: `vr = max(scaled_vr, Sports.<sport>.vr)`.
 - Resolve the location timezone from coordinates in backend orchestration; do not require frontend `tz`.
 - Use Open-Meteo `direct_normal_irradiance` as the radiation source and derive MRT with `pvlib` + `pythermalcomfort.models.solar_gain`.
 - Globe temperature (`tg`) is out of scope and must not be introduced.
 - Do not introduce assumptions before model call:
   - no clamping
   - no default fill
-  - no business-side input remapping beyond the approved MRT pipeline, wind-height scaling, and sport default floor
+  - no business-side input remapping beyond the approved MRT pipeline and wind-height scaling
 - If required weather or MRT inputs are missing/uncertain (`tdb`, `rh`, `wind`, `radiation`, `tr`), return `422` with `unknown_inputs` under `response.forecast[*].heat_risk`.
 - Return pythermalcomfort output in `response.heat_risk` with original field names.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -124,7 +124,6 @@ Example response:
         "mean_radiant_temperature_c": 37.25,
         "relative_humidity_pct": 62.0,
         "wind_speed_10m_ms": 1.5,
-        "wind_speed_effective_ms": 1.02,
         "direct_normal_irradiance_wm2": 700.0
       },
       "heat_risk": {
@@ -164,9 +163,8 @@ Example response:
    - derive `dni = direct_normal_irradiance * 0.75`
    - compute `delta_mrt` with `pythermalcomfort.models.solar_gain`
    - derive `tr = tdb + delta_mrt`
-8. Convert `wind_speed_10m_ms` to `wind_speed_effective_ms` using
-   `pythermalcomfort.utils.scale_wind_speed_log(...)`, then apply the sport floor
-   with `max(scaled_vr, Sports.<sport>.vr)`.
+8. Convert `wind_speed_10m_ms` to the model's required 1.1 m wind speed using
+   `pythermalcomfort.utils.scale_wind_speed_log(...)`.
 9. Run `sports_heat_stress_risk` for each complete forecast row.
 10. Skip incomplete rows and treat the earliest complete row as `forecast[0]`.
 11. Return `422` only when no complete forecast row exists; the error payload is derived

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pandas>=2.3.3",
     "pvlib>=0.13.1",
     "pydantic-settings>=2.13.0",
-    "pythermalcomfort>=3.9.0",
+    "pythermalcomfort==3.9.2",
     "timezonefinder>=8.1.0",
     "uvicorn[standard]>=0.41.0",
 ]

--- a/backend/src/sma_extreme_heat_backend/schemas/home.py
+++ b/backend/src/sma_extreme_heat_backend/schemas/home.py
@@ -62,7 +62,6 @@ class ForecastInputs(BaseModel):
     mean_radiant_temperature_c: FiniteFloat
     relative_humidity_pct: FiniteFloat
     wind_speed_10m_ms: FiniteFloat
-    wind_speed_effective_ms: FiniteFloat
     direct_normal_irradiance_wm2: FiniteFloat
 
 

--- a/backend/src/sma_extreme_heat_backend/services/risk_service.py
+++ b/backend/src/sma_extreme_heat_backend/services/risk_service.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from functools import cache
 
 import pandas as pd
-from pythermalcomfort.models.sports_heat_stress_risk import Sports
 from pythermalcomfort.utils.scale_wind_speed_log import scale_wind_speed_log
 
 from sma_extreme_heat_backend.calculators.sports_heat_stress import (
@@ -169,7 +168,6 @@ class RiskService:
         # the backend could not produce any usable current/forecast point.
         raise self._missing_input_error_for_point(
             point=first_candidate_point,
-            sport=sport,
         )
 
     @staticmethod
@@ -201,7 +199,6 @@ class RiskService:
         self,
         *,
         point: pd.Series,
-        sport: str,
     ) -> ModelInputUnavailableError:
         """Build the public 422 error for a candidate row with missing required inputs."""
 
@@ -209,7 +206,6 @@ class RiskService:
             unknown_inputs=self._missing_required_input_fields(point),
             available_inputs=self._available_inputs_for_point(
                 point=point,
-                sport=sport,
             ),
         )
 
@@ -217,22 +213,15 @@ class RiskService:
         self,
         *,
         point: pd.Series,
-        sport: str,
     ) -> dict[str, float | None]:
         """Expose the current point inputs using public API field names."""
 
         wind_speed_10m_ms = _to_optional_float(point.wind)
-        wind_speed_effective_ms = (
-            self._resolve_model_wind_speed(vr=wind_speed_10m_ms, sport=sport)
-            if wind_speed_10m_ms is not None
-            else None
-        )
         return {
             "air_temperature_c": _to_optional_float(point.tdb),
             "mean_radiant_temperature_c": _to_optional_float(point.tr),
             "relative_humidity_pct": _to_optional_float(point.rh),
             "wind_speed_10m_ms": wind_speed_10m_ms,
-            "wind_speed_effective_ms": wind_speed_effective_ms,
             "direct_normal_irradiance_wm2": _to_optional_float(point.radiation),
         }
 
@@ -253,16 +242,13 @@ class RiskService:
 
         wind_speed_10m_ms = float(point.wind)
         # Convert the provider's 10 m wind speed into the model's required 1.1 m input.
-        wind_speed_effective_ms = self._resolve_model_wind_speed(
-            vr=wind_speed_10m_ms,
-            sport=sport,
-        )
+        wind_speed_model_ms = self._resolve_model_wind_speed(vr=wind_speed_10m_ms)
         computed = self.calculator.model_sports_heat_stress(
             SportsHeatStressInput(
                 sport=sport,
                 tdb=float(point.tdb),
                 rh=float(point.rh),
-                vr=wind_speed_effective_ms,
+                vr=wind_speed_model_ms,
                 tr=float(point.tr),
             )
         )
@@ -275,17 +261,16 @@ class RiskService:
                 mean_radiant_temperature_c=float(point.tr),
                 relative_humidity_pct=float(point.rh),
                 wind_speed_10m_ms=wind_speed_10m_ms,
-                wind_speed_effective_ms=wind_speed_effective_ms,
                 direct_normal_irradiance_wm2=float(point.radiation),
             ),
             heat_risk=ForecastHeatRisk.model_validate(computed.data),
         )
 
     @staticmethod
-    def _resolve_model_wind_speed(*, vr: float, sport: str) -> float:
-        """Convert 10 m wind speed to the effective model wind speed."""
+    def _resolve_model_wind_speed(*, vr: float) -> float:
+        """Convert 10 m wind speed to the model's required 1.1 m wind speed."""
 
-        scaled_vr = float(
+        return float(
             scale_wind_speed_log(
                 v_z1=vr,
                 z2=WIND_SPEED_REFACTOR_CONFIG.model_height_meters,
@@ -295,8 +280,6 @@ class RiskService:
                 round_output=True,
             ).v_z2
         )
-        sport_default_vr = getattr(Sports, sport).vr
-        return max(scaled_vr, sport_default_vr)
 
 
 @cache

--- a/backend/tests/api/test_home_risk.py
+++ b/backend/tests/api/test_home_risk.py
@@ -49,7 +49,6 @@ class SuccessfulRiskService:
                         mean_radiant_temperature_c=37.25,
                         relative_humidity_pct=62.0,
                         wind_speed_10m_ms=1.5,
-                        wind_speed_effective_ms=1.02,
                         direct_normal_irradiance_wm2=700.0,
                     ),
                     heat_risk=ForecastHeatRisk(
@@ -68,7 +67,6 @@ class SuccessfulRiskService:
                         mean_radiant_temperature_c=38.1,
                         relative_humidity_pct=61.0,
                         wind_speed_10m_ms=1.6,
-                        wind_speed_effective_ms=1.09,
                         direct_normal_irradiance_wm2=740.0,
                     ),
                     heat_risk=ForecastHeatRisk(
@@ -105,7 +103,6 @@ class MissingInputRiskService:
                 "mean_radiant_temperature_c": 35.0,
                 "relative_humidity_pct": 60.0,
                 "wind_speed_10m_ms": None,
-                "wind_speed_effective_ms": None,
                 "direct_normal_irradiance_wm2": 700.0,
             },
         )
@@ -148,7 +145,6 @@ def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) 
                     "mean_radiant_temperature_c": 37.25,
                     "relative_humidity_pct": 62.0,
                     "wind_speed_10m_ms": 1.5,
-                    "wind_speed_effective_ms": 1.02,
                     "direct_normal_irradiance_wm2": 700.0,
                 },
                 "heat_risk": {
@@ -167,7 +163,6 @@ def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) 
                     "mean_radiant_temperature_c": 38.1,
                     "relative_humidity_pct": 61.0,
                     "wind_speed_10m_ms": 1.6,
-                    "wind_speed_effective_ms": 1.09,
                     "direct_normal_irradiance_wm2": 740.0,
                 },
                 "heat_risk": {
@@ -180,6 +175,20 @@ def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) 
             },
         ],
     }
+
+
+def test_forecast_heat_risk_accepts_legacy_scale_score() -> None:
+    """The public schema should continue accepting finite model scores."""
+
+    heat_risk = ForecastHeatRisk(
+        risk_level_interpolated=0.8,
+        t_medium=34.5,
+        t_high=37.1,
+        t_extreme=39.2,
+        recommendation="Increase hydration & modify clothing",
+    )
+
+    assert heat_risk.risk_level_interpolated == 0.8
 
 
 def test_options_home_risk_allows_netlify_preview_origin_via_regex(monkeypatch) -> None:

--- a/backend/tests/services/test_risk_service.py
+++ b/backend/tests/services/test_risk_service.py
@@ -196,7 +196,6 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
         "mean_radiant_temperature_c": 37.25,
         "relative_humidity_pct": 62.0,
         "wind_speed_10m_ms": 1.5,
-        "wind_speed_effective_ms": 1.02,
         "direct_normal_irradiance_wm2": 700.0,
     }
     assert first.forecast[0].heat_risk.model_dump() == {
@@ -215,7 +214,6 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
                 "mean_radiant_temperature_c": 37.25,
                 "relative_humidity_pct": 62.0,
                 "wind_speed_10m_ms": 1.5,
-                "wind_speed_effective_ms": 1.02,
                 "direct_normal_irradiance_wm2": 700.0,
             },
             "heat_risk": {
@@ -234,7 +232,6 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
                 "mean_radiant_temperature_c": 38.25,
                 "relative_humidity_pct": 63.0,
                 "wind_speed_10m_ms": 1.6,
-                "wind_speed_effective_ms": 1.09,
                 "direct_normal_irradiance_wm2": 750.0,
             },
             "heat_risk": {
@@ -253,7 +250,6 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
                 "mean_radiant_temperature_c": 39.25,
                 "relative_humidity_pct": 64.0,
                 "wind_speed_10m_ms": 1.7,
-                "wind_speed_effective_ms": 1.16,
                 "direct_normal_irradiance_wm2": 800.0,
             },
             "heat_risk": {
@@ -434,10 +430,10 @@ async def test_risk_service_returns_same_forecast_for_all_profiles(
     ]
 
 
-async def test_risk_service_uses_sport_default_when_scaled_wind_is_lower(
+async def test_risk_service_uses_only_height_scaled_wind_for_lower_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Sport wind-speed floors should override slower scaled wind speeds."""
+    """Lower wind speeds should only be scaled to the model height."""
 
     weather_client = FakeWeatherClient()
     calculator = FakeCalculator()
@@ -448,7 +444,7 @@ async def test_risk_service_uses_sport_default_when_scaled_wind_is_lower(
         ttl_seconds=600,
     )
 
-    response = await service.calculate_home_risk(
+    await service.calculate_home_risk(
         RiskRequest(
             sport="SOCCER",
             latitude=-33.847,
@@ -457,14 +453,13 @@ async def test_risk_service_uses_sport_default_when_scaled_wind_is_lower(
         )
     )
 
-    assert calculator.payloads[0].vr == 1.0
-    assert response.forecast[0].inputs.wind_speed_effective_ms == 1.0
+    assert calculator.payloads[0].vr == pytest.approx(0.61)
 
 
-async def test_risk_service_preserves_scaled_wind_when_above_sport_default(
+async def test_risk_service_uses_only_height_scaled_wind_for_higher_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Scaled wind speed should pass through when already above the sport floor."""
+    """Higher wind speeds should still only use the height-scaled value."""
 
     weather_client = FakeWeatherClient()
     calculator = FakeCalculator()
@@ -485,7 +480,7 @@ async def test_risk_service_preserves_scaled_wind_when_above_sport_default(
     )
 
     assert calculator.payloads[0].vr == pytest.approx(2.72)
-    assert response.forecast[0].inputs.wind_speed_effective_ms == pytest.approx(2.72)
+    assert response.forecast[0].inputs.wind_speed_10m_ms == pytest.approx(4.0)
 
 
 async def test_risk_service_skips_future_points_with_missing_inputs(
@@ -553,7 +548,6 @@ async def test_risk_service_skips_incomplete_leading_rows_and_uses_next_complete
         "mean_radiant_temperature_c": 38.25,
         "relative_humidity_pct": 63.0,
         "wind_speed_10m_ms": 1.6,
-        "wind_speed_effective_ms": 1.09,
         "direct_normal_irradiance_wm2": 750.0,
     }
 
@@ -593,7 +587,6 @@ async def test_risk_service_raises_422_when_no_complete_forecast_point_exists(
             "mean_radiant_temperature_c": 37.25,
             "relative_humidity_pct": 62.0,
             "wind_speed_10m_ms": None,
-            "wind_speed_effective_ms": None,
             "direct_normal_irradiance_wm2": 700.0,
         }
     else:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -694,7 +694,7 @@ wheels = [
 
 [[package]]
 name = "pythermalcomfort"
-version = "3.9.0"
+version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numba" },
@@ -702,9 +702,9 @@ dependencies = [
     { name = "scipy" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/7b/df280aadc06b1e2a77f3c80e8cc1bb81c1de3e4aa1afe61427ca1f3c1477/pythermalcomfort-3.9.0.tar.gz", hash = "sha256:982cb60fc08e3f1f7ac98f439a8e466413142eb2a934ae9ad42b109569967ff6", size = 473865, upload-time = "2026-02-17T07:31:02.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/74/4d2c0ac6bfd2a56c25f66dedc998cf1acc3b753ec5329a209218031826bd/pythermalcomfort-3.9.2.tar.gz", hash = "sha256:b388eb29c79215aa26f121eee2624567239aa99236f604874f8f2b65dd7e454c", size = 475732, upload-time = "2026-04-16T03:53:59.913Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/ec/90c0f8d548bda650c63aa1c032e0541fe3828c69bd370fff7838ee0b4591/pythermalcomfort-3.9.0-py2.py3-none-any.whl", hash = "sha256:3de525f221e73ab2c6d3718eb37fef99d095522ca66d5aa05d57f3e53407032e", size = 228634, upload-time = "2026-02-17T07:31:01.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d5/a70f5a714d6bfb8be39d7e5daefc3be4c40c5229ba9ded4d004c6e6a90e0/pythermalcomfort-3.9.2-py2.py3-none-any.whl", hash = "sha256:b04f5fcea641734c132fd46bd5496bd9981444865d45110a5475ebef573e3272", size = 230443, upload-time = "2026-04-16T03:53:58.233Z" },
 ]
 
 [[package]]
@@ -931,7 +931,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pvlib", specifier = ">=0.13.1" },
     { name = "pydantic-settings", specifier = ">=2.13.0" },
-    { name = "pythermalcomfort", specifier = ">=3.9.0" },
+    { name = "pythermalcomfort", specifier = "==3.9.2" },
     { name = "timezonefinder", specifier = ">=8.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]

--- a/frontend/src/api/heatRisk.test.ts
+++ b/frontend/src/api/heatRisk.test.ts
@@ -45,7 +45,6 @@ describe("isHeatRiskApiResponse", () => {
               mean_radiant_temperature_c: 37.25,
               relative_humidity_pct: 62,
               wind_speed_10m_ms: 1.5,
-              wind_speed_effective_ms: 1.02,
               direct_normal_irradiance_wm2: 700,
             },
             heat_risk: {
@@ -82,7 +81,6 @@ describe("isHeatRiskApiResponse", () => {
               mean_radiant_temperature_c: 37.25,
               relative_humidity_pct: 62,
               wind_speed_10m_ms: 1.5,
-              wind_speed_effective_ms: 1.02,
               direct_normal_irradiance_wm2: 700,
             },
             heat_risk: {
@@ -118,7 +116,6 @@ describe("isHeatRiskApiResponse", () => {
               mean_radiant_temperature_c: 37.25,
               relative_humidity_pct: 62,
               wind_speed_10m_ms: 1.5,
-              wind_speed_effective_ms: 1.02,
               direct_normal_irradiance_wm2: 700,
             },
             heat_risk: {

--- a/frontend/src/api/heatRisk.ts
+++ b/frontend/src/api/heatRisk.ts
@@ -27,7 +27,6 @@ export interface ForecastInputsApiData {
   mean_radiant_temperature_c: number;
   relative_humidity_pct: number;
   wind_speed_10m_ms: number;
-  wind_speed_effective_ms: number;
   direct_normal_irradiance_wm2: number;
 }
 
@@ -128,7 +127,6 @@ function isForecastInputsApiData(
     isFiniteNumber(value.mean_radiant_temperature_c) &&
     isFiniteNumber(value.relative_humidity_pct) &&
     isFiniteNumber(value.wind_speed_10m_ms) &&
-    isFiniteNumber(value.wind_speed_effective_ms) &&
     isFiniteNumber(value.direct_normal_irradiance_wm2)
   );
 }

--- a/frontend/src/components/home/FiltersSection.tsx
+++ b/frontend/src/components/home/FiltersSection.tsx
@@ -13,11 +13,6 @@ import {
 import { type MouseEvent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  heatRiskProfiles,
-  isHeatRiskProfile,
-  type HeatRiskProfile,
-} from "@/domain/heatRiskProfile";
-import {
   isSportType,
   sports,
   toSportAssetName,
@@ -43,13 +38,16 @@ const SPORT_IMAGE_HEIGHT = 104;
 export function FiltersSection() {
   const { t } = useTranslation();
   const locationCombobox = useCombobox();
+  /*
   const profile = useHomeStore((state) => state.profile);
+  const setProfile = useHomeStore((state) => state.setProfile);
+  */
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
-  const setProfile = useHomeStore((state) => state.setProfile);
   const setSport = useHomeStore((state) => state.setSport);
   const [hasSportImageError, setHasSportImageError] = useState(false);
 
+  /*
   const profileOptions = useMemo<SelectOption<HeatRiskProfile>[]>(
     () =>
       heatRiskProfiles.map((profileMeta) => ({
@@ -58,7 +56,7 @@ export function FiltersSection() {
       })),
     [t],
   );
-
+  */
   const sportOptions = useMemo<SelectOption<SportType>[]>(
     () =>
       sports.map((sportMeta) => ({
@@ -105,12 +103,13 @@ export function FiltersSection() {
     </Combobox.Option>
   ));
 
+  /*
   const handleProfileChange = (value: string | null) => {
     if (value !== null && isHeatRiskProfile(value)) {
       setProfile(value);
     }
   };
-
+  */
   const handleLocationInputClick = (event: MouseEvent<HTMLInputElement>) => {
     if (isShowingCommittedLocation) {
       event.currentTarget.select();
@@ -141,6 +140,7 @@ export function FiltersSection() {
   return (
     <SectionCard>
       <Stack gap={CONTENT_GAP}>
+        {/*
         <Group wrap="nowrap" align="center" gap={CONTENT_GAP}>
           <Text fw={600} w={FIELD_LABEL_WIDTH} ta="right">
             {t("home.sections.filters.profileLabel")}:
@@ -157,7 +157,7 @@ export function FiltersSection() {
             />
           </Box>
         </Group>
-
+        */}
         <Group wrap="nowrap" align="center" gap={CONTENT_GAP}>
           <Text fw={600} w={FIELD_LABEL_WIDTH} ta="right">
             {t("home.sections.filters.locationLabel")}:

--- a/frontend/src/domain/riskMeta.ts
+++ b/frontend/src/domain/riskMeta.ts
@@ -36,7 +36,7 @@ export const RISK_LEVEL_META: Record<RiskLevel, LegacyRiskMetaEntry> =
   );
 
 /**
- * Converts an interpolated risk score (0-4) into a discrete risk level.
+ * Converts an interpolated risk score into a discrete risk level.
  */
 export function toRiskLevel(score: number): RiskLevel {
   return toRiskLevelFromRegistry(score);

--- a/frontend/src/domain/riskRegistry.test.ts
+++ b/frontend/src/domain/riskRegistry.test.ts
@@ -2,16 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   getRiskBadgeForegroundColor,
   getRiskBands,
+  toRiskDisplayScore,
   toRiskLevel,
 } from "@/domain/riskRegistry";
 
 describe("toRiskLevel", () => {
   it("maps threshold boundaries into the expected risk levels", () => {
     expect(toRiskLevel(Number.NaN)).toBe("low");
-    expect(toRiskLevel(0.99)).toBe("low");
-    expect(toRiskLevel(1)).toBe("moderate");
-    expect(toRiskLevel(2)).toBe("high");
-    expect(toRiskLevel(3)).toBe("extreme");
+    expect(toRiskLevel(1)).toBe("low");
+    expect(toRiskLevel(2)).toBe("moderate");
+    expect(toRiskLevel(3)).toBe("high");
+    expect(toRiskLevel(4)).toBe("extreme");
   });
 });
 
@@ -23,6 +24,15 @@ describe("getRiskBands", () => {
       { level: "high", lower: 2, upper: 3, color: "#CF3838" },
       { level: "extreme", lower: 3, upper: 4, color: "#8C2439" },
     ]);
+  });
+});
+
+describe("toRiskDisplayScore", () => {
+  it("anchors the maximum model score to the high/extreme boundary", () => {
+    expect(toRiskDisplayScore(0.8)).toBe(0);
+    expect(toRiskDisplayScore(1.5)).toBe(0.5);
+    expect(toRiskDisplayScore(3.5)).toBe(2.5);
+    expect(toRiskDisplayScore(4)).toBe(3);
   });
 });
 

--- a/frontend/src/domain/riskRegistry.ts
+++ b/frontend/src/domain/riskRegistry.ts
@@ -27,7 +27,7 @@ export const RISK_LEVELS: readonly RiskLevel[] = [
   "moderate",
   "high",
   "extreme",
-];
+] as const;
 export const MAX_RISK_SCORE = 4;
 
 export const RISK_REGISTRY: Record<RiskLevel, RiskRegistryEntry> = {
@@ -90,18 +90,46 @@ export const RISK_REGISTRY: Record<RiskLevel, RiskRegistryEntry> = {
 };
 
 /**
- * Converts an interpolated risk score (0-4) into a discrete risk level.
+ * Converts an interpolated risk score into a discrete risk level.
  */
 export function toRiskLevel(score: number): RiskLevel {
   const safeScore = Number.isFinite(score) ? score : 0;
 
-  for (const level of RISK_LEVELS) {
-    if (safeScore < RISK_REGISTRY[level].scoreUpperExclusive) {
-      return level;
-    }
+  if (safeScore < 2) {
+    return "low";
+  }
+  if (safeScore < 3) {
+    return "moderate";
+  }
+  if (safeScore < 4) {
+    return "high";
+  }
+  return "extreme";
+}
+
+/**
+ * Maps a raw risk score onto the shared chart display coordinate system.
+ * The pythermalcomfort 3.9.2 model caps scores at 4.0, and that maximum score
+ * should render on the High/Extreme boundary rather than within the Extreme band.
+ */
+export function toRiskDisplayScore(score: number): number | null {
+  if (!Number.isFinite(score)) {
+    return null;
   }
 
-  return "extreme";
+  if (score <= 1) {
+    return 0;
+  }
+
+  if (score === MAX_RISK_SCORE) {
+    return MAX_RISK_SCORE - 1;
+  }
+
+  if (score > MAX_RISK_SCORE) {
+    return MAX_RISK_SCORE;
+  }
+
+  return score - 1;
 }
 
 /**

--- a/frontend/src/lib/homeRisk.test.ts
+++ b/frontend/src/lib/homeRisk.test.ts
@@ -96,7 +96,7 @@ describe("toForecastDays", () => {
           direct_normal_irradiance_wm2: 650,
         },
         heat_risk: {
-          risk_level_interpolated: 0.8,
+          risk_level_interpolated: 1.8,
           t_medium: 34.5,
           t_high: 37.1,
           t_extreme: 39.2,
@@ -114,7 +114,7 @@ describe("toForecastDays", () => {
           direct_normal_irradiance_wm2: 670,
         },
         heat_risk: {
-          risk_level_interpolated: 1.2,
+          risk_level_interpolated: 2.2,
           t_medium: 34.5,
           t_high: 37.1,
           t_extreme: 39.2,
@@ -132,7 +132,7 @@ describe("toForecastDays", () => {
           direct_normal_irradiance_wm2: 690,
         },
         heat_risk: {
-          risk_level_interpolated: 1.4,
+          risk_level_interpolated: 2.4,
           t_medium: 34.5,
           t_high: 37.1,
           t_extreme: 39.2,
@@ -146,9 +146,9 @@ describe("toForecastDays", () => {
         date: "2026-03-10T00:00:00+08:45",
         risk: "moderate",
         points: [
-          { time: "00:00", value: 0.8 },
-          { time: "01:00", value: 1.2 },
-          { time: "02:00", value: 1.4 },
+          { time: "00:00", value: 1.8 },
+          { time: "01:00", value: 2.2 },
+          { time: "02:00", value: 2.4 },
         ],
       },
     ]);
@@ -168,7 +168,7 @@ describe("toForecastDays", () => {
             direct_normal_irradiance_wm2: 650,
           },
           heat_risk: {
-            risk_level_interpolated: 0.8,
+            risk_level_interpolated: 1.8,
             t_medium: 34.5,
             t_high: 37.1,
             t_extreme: 39.2,

--- a/frontend/src/lib/homeRisk.test.ts
+++ b/frontend/src/lib/homeRisk.test.ts
@@ -43,7 +43,6 @@ describe("getCurrentForecastPoint", () => {
               mean_radiant_temperature_c: 37,
               relative_humidity_pct: 62,
               wind_speed_10m_ms: 1.5,
-              wind_speed_effective_ms: 1.02,
               direct_normal_irradiance_wm2: 700,
             },
             heat_risk: {
@@ -62,7 +61,6 @@ describe("getCurrentForecastPoint", () => {
               mean_radiant_temperature_c: 38,
               relative_humidity_pct: 61,
               wind_speed_10m_ms: 1.6,
-              wind_speed_effective_ms: 1.09,
               direct_normal_irradiance_wm2: 740,
             },
             heat_risk: {
@@ -95,7 +93,6 @@ describe("toForecastDays", () => {
           mean_radiant_temperature_c: 35,
           relative_humidity_pct: 60,
           wind_speed_10m_ms: 1.2,
-          wind_speed_effective_ms: 1.0,
           direct_normal_irradiance_wm2: 650,
         },
         heat_risk: {
@@ -114,7 +111,6 @@ describe("toForecastDays", () => {
           mean_radiant_temperature_c: 36,
           relative_humidity_pct: 59,
           wind_speed_10m_ms: 1.3,
-          wind_speed_effective_ms: 1.1,
           direct_normal_irradiance_wm2: 670,
         },
         heat_risk: {
@@ -133,7 +129,6 @@ describe("toForecastDays", () => {
           mean_radiant_temperature_c: 37,
           relative_humidity_pct: 58,
           wind_speed_10m_ms: 1.4,
-          wind_speed_effective_ms: 1.2,
           direct_normal_irradiance_wm2: 690,
         },
         heat_risk: {
@@ -170,7 +165,6 @@ describe("toForecastDays", () => {
             mean_radiant_temperature_c: 35,
             relative_humidity_pct: 60,
             wind_speed_10m_ms: 1.2,
-            wind_speed_effective_ms: 1.0,
             direct_normal_irradiance_wm2: 650,
           },
           heat_risk: {

--- a/frontend/src/lib/riskCharts.test.ts
+++ b/frontend/src/lib/riskCharts.test.ts
@@ -15,7 +15,7 @@ const forecastLabels = {
 };
 
 describe("buildForecastOption", () => {
-  it("adds threshold crossing points to the visual forecast series", () => {
+  it("adds remapped threshold crossing points to the visual forecast series", () => {
     const option = buildForecastOption(
       [
         { time: "08:00", value: 0.5 },
@@ -77,33 +77,32 @@ describe("buildForecastOption", () => {
     });
     expect(visualSeries).toMatchObject({
       data: [
-        [480, 0.5],
-        [495, 1],
-        [525, 2],
-        [540, 2.5],
+        [480, 0],
+        [520, 1],
+        [540, 1.5],
       ],
     });
     expect(tooltipSeries).toMatchObject({
       data: [
-        [480, 0.5],
-        [540, 2.5],
+        [480, 0],
+        [540, 1.5],
       ],
     });
     expect(pointSeries).toMatchObject({
       symbol: "circle",
       symbolSize: 6,
       data: [
-        [480, 0.5],
-        [540, 2.5],
+        [480, 0],
+        [540, 1.5],
       ],
     });
   });
 
-  it("renders zero-risk forecasts with the standard line styling and point markers", () => {
+  it("pins sub-1 forecasts to the low baseline while keeping the line styling", () => {
     const option = buildForecastOption(
       [
-        { time: "08:00", value: 0 },
-        { time: "09:00", value: 0 },
+        { time: "08:00", value: 0.2 },
+        { time: "09:00", value: 0.8 },
       ],
       forecastLabels,
     );
@@ -155,6 +154,86 @@ describe("buildForecastOption", () => {
         [540, 0],
       ],
     });
+  });
+
+  it("keeps tooltip values on the raw risk scale", () => {
+    const option = buildForecastOption(
+      [
+        { time: "08:00", value: 0.5 },
+        { time: "09:00", value: 2.5 },
+      ],
+      forecastLabels,
+      "Today",
+    );
+    const tooltip =
+      option.tooltip && !Array.isArray(option.tooltip) ? option.tooltip : null;
+
+    expect(typeof tooltip?.formatter).toBe("function");
+
+    const formatter = tooltip?.formatter as (params: unknown) => string;
+    const rendered = formatter([
+      {
+        axisValue: 540,
+        name: "09:00",
+        value: [540, 1.5],
+      },
+    ]);
+
+    expect(rendered).toContain("2.5");
+    expect(rendered).not.toContain("1.5");
+  });
+
+  it("renders a max score point on the high/extreme boundary", () => {
+    const option = buildForecastOption(
+      [
+        { time: "08:00", value: 3.5 },
+        { time: "09:00", value: 4.0 },
+      ],
+      forecastLabels,
+      "Today",
+    );
+    const series = Array.isArray(option.series) ? option.series : [];
+    const visualSeries = series.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "name" in entry &&
+        entry.name === "Risk-visual",
+    );
+    const pointSeries = series.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "name" in entry &&
+        entry.name === "Risk-points",
+    );
+    const tooltip =
+      option.tooltip && !Array.isArray(option.tooltip) ? option.tooltip : null;
+
+    expect(visualSeries).toMatchObject({
+      data: [
+        [480, 2.5],
+        [540, 3],
+      ],
+    });
+    expect(pointSeries).toMatchObject({
+      data: [
+        [480, 2.5],
+        [540, 3],
+      ],
+    });
+
+    const formatter = tooltip?.formatter as (params: unknown) => string;
+    const rendered = formatter([
+      {
+        axisValue: 540,
+        name: "09:00",
+        value: [540, 3],
+      },
+    ]);
+
+    expect(rendered).toContain("4.0");
+    expect(rendered).not.toContain("3.0");
   });
 
   it("keeps mobile x-axis labels on a regular cadence", () => {

--- a/frontend/src/lib/riskCharts.ts
+++ b/frontend/src/lib/riskCharts.ts
@@ -10,6 +10,7 @@ import {
   getRiskBands,
   getRiskColor,
   MAX_RISK_SCORE,
+  toRiskDisplayScore,
 } from "@/domain/riskRegistry";
 
 const FORECAST_LINE_COLOR = USYD_ORANGE_HEX;
@@ -71,6 +72,7 @@ interface ForecastLabels {
 }
 
 interface ForecastChartPoint extends ForecastPoint {
+  displayValue: number;
   minuteOffset: number;
 }
 
@@ -139,6 +141,7 @@ function toForecastCoordinatePoints(
 
     return {
       ...point,
+      displayValue: toRiskDisplayScore(point.value) ?? 0,
       minuteOffset,
     };
   });
@@ -159,20 +162,26 @@ function toForecastChartPoints(
   for (let index = 1; index < points.length; index += 1) {
     const previousPoint = points[index - 1];
     const nextPoint = points[index];
-    const valueDelta = nextPoint.value - previousPoint.value;
+    const valueDelta = nextPoint.displayValue - previousPoint.displayValue;
     const minuteDelta = nextPoint.minuteOffset - previousPoint.minuteOffset;
 
     if (valueDelta !== 0 && minuteDelta > 0) {
       const crossingPoints = thresholds
         .filter((threshold) => {
-          const lowerValue = Math.min(previousPoint.value, nextPoint.value);
-          const upperValue = Math.max(previousPoint.value, nextPoint.value);
+          const lowerValue = Math.min(
+            previousPoint.displayValue,
+            nextPoint.displayValue,
+          );
+          const upperValue = Math.max(
+            previousPoint.displayValue,
+            nextPoint.displayValue,
+          );
 
           return threshold > lowerValue && threshold < upperValue;
         })
         .map((threshold) => ({
           threshold,
-          ratio: (threshold - previousPoint.value) / valueDelta,
+          ratio: (threshold - previousPoint.displayValue) / valueDelta,
         }))
         .filter(({ ratio }) => ratio > 0 && ratio < 1)
         .sort((left, right) => left.ratio - right.ratio);
@@ -182,8 +191,11 @@ function toForecastChartPoints(
           previousPoint.minuteOffset + minuteDelta * crossingPoint.ratio;
 
         expandedPoints.push({
+          value:
+            previousPoint.value +
+            (nextPoint.value - previousPoint.value) * crossingPoint.ratio,
+          displayValue: crossingPoint.threshold,
           time: formatForecastMinutesLabel(minuteOffset),
-          value: crossingPoint.threshold,
           minuteOffset,
         });
       }
@@ -226,7 +238,7 @@ function findNearestForecastPoint(
 }
 
 function toForecastPointDatum(point: ForecastChartPoint): [number, number] {
-  return [point.minuteOffset, point.value];
+  return [point.minuteOffset, point.displayValue];
 }
 
 function isForecastAxisTickAligned(
@@ -323,7 +335,7 @@ function toRiskBandValues(
 ): Array<[number, number]> {
   return points.map((point) => [
     point.minuteOffset,
-    getBandUpperValue(point.value, upper),
+    getBandUpperValue(point.displayValue, upper),
   ]);
 }
 

--- a/frontend/src/lib/riskGauge.test.ts
+++ b/frontend/src/lib/riskGauge.test.ts
@@ -29,25 +29,30 @@ function getGraphicElements(option: ReturnType<typeof buildRiskGaugeOption>) {
 describe("riskGauge helpers", () => {
   it("maps threshold scores to the expected active levels", () => {
     expect(getRiskGaugeActiveLevel(0)).toBe("low");
-    expect(getRiskGaugeActiveLevel(1)).toBe("moderate");
-    expect(getRiskGaugeActiveLevel(2)).toBe("high");
-    expect(getRiskGaugeActiveLevel(3)).toBe("extreme");
+    expect(getRiskGaugeActiveLevel(1.5)).toBe("low");
+    expect(getRiskGaugeActiveLevel(2.5)).toBe("moderate");
+    expect(getRiskGaugeActiveLevel(3.5)).toBe("high");
     expect(getRiskGaugeActiveLevel(4)).toBe("extreme");
   });
 
-  it("maps threshold scores to the expected pointer angles", () => {
-    expect(getRiskGaugePointerAngle(0)).toBe(180);
-    expect(getRiskGaugePointerAngle(1)).toBe(135);
-    expect(getRiskGaugePointerAngle(2)).toBe(90);
-    expect(getRiskGaugePointerAngle(3)).toBe(45);
-    expect(getRiskGaugePointerAngle(4)).toBe(0);
+  it("maps raw scores onto the expected pointer angles", () => {
+    expect(getRiskGaugePointerAngle(0.5)).toBe(180);
+    expect(getRiskGaugePointerAngle(1)).toBe(180);
+    expect(getRiskGaugePointerAngle(1.5)).toBe(157.5);
+    expect(getRiskGaugePointerAngle(2.5)).toBe(112.5);
+    expect(getRiskGaugePointerAngle(3.5)).toBe(67.5);
+    expect(getRiskGaugePointerAngle(4)).toBe(45);
   });
 
-  it("clamps out-of-range scores and falls back to N/A for unavailable values", () => {
+  it("remaps raw scores into the display range and falls back to N/A when unavailable", () => {
     expect(normalizeRiskGaugeScore(-1)).toBe(0);
+    expect(normalizeRiskGaugeScore(0.8)).toBe(0);
+    expect(normalizeRiskGaugeScore(1.5)).toBe(0.5);
+    expect(normalizeRiskGaugeScore(4)).toBe(3);
     expect(normalizeRiskGaugeScore(6)).toBe(4);
     expect(getRiskGaugePointerAngle(Number.NaN)).toBeNull();
     expect(formatRiskGaugeValue(Number.NaN, "N/A")).toBe("N/A");
+    expect(formatRiskGaugeValue(4, "N/A")).toBe("4.0");
   });
 
   it("resolves default and clamped gauge widths from a single helper", () => {
@@ -59,7 +64,7 @@ describe("riskGauge helpers", () => {
     expect(getRiskGaugeWidth(true, Number.NaN)).toBe(RISK_GAUGE_MIN_WIDTH);
   });
 
-  it("builds a semicircle echarts gauge with legacy-style band labels", () => {
+  it("builds a semicircle echarts gauge with remapped display coordinates", () => {
     const option = buildRiskGaugeOption(2.4, riskGaugeLabels, false, 400);
     const [bandSeries, overlaySeries] = Array.isArray(option.series)
       ? option.series
@@ -80,7 +85,7 @@ describe("riskGauge helpers", () => {
       splitLine: {
         show: false,
       },
-      data: [{ value: 2.4 }],
+      data: [{ value: 1.4 }],
     });
     expect(overlaySeries).toMatchObject({
       type: "gauge",
@@ -102,14 +107,14 @@ describe("riskGauge helpers", () => {
       title: {
         show: false,
       },
-      data: [{ value: 2.4 }],
+      data: [{ value: 1.4 }],
     });
     expect(graphicElements).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: "polygon",
           style: expect.objectContaining({
-            fill: getRiskColor("high"),
+            fill: getRiskColor("moderate"),
           }),
         }),
       ]),

--- a/frontend/src/lib/riskGauge.ts
+++ b/frontend/src/lib/riskGauge.ts
@@ -6,6 +6,7 @@ import {
   getRiskBands,
   getRiskColor,
   MAX_RISK_SCORE,
+  toRiskDisplayScore,
 } from "@/domain/riskRegistry";
 
 export const RISK_GAUGE_MIN_SCORE = 0;
@@ -62,9 +63,9 @@ type RiskGaugeGraphic = {
 };
 type RiskGaugeMeasurements = {
   activeLevel: RiskLevel | null;
+  displayScore: number | null;
   geometry: RiskGaugeGeometry;
   layout: RiskGaugeLayout;
-  normalizedScore: number | null;
   pointerAngle: number | null;
   valueLayout: RiskGaugeValueLayout;
 };
@@ -306,27 +307,25 @@ function getRiskGaugeMeasurements(
   containerWidth?: number,
 ): RiskGaugeMeasurements {
   const { geometry, layout } = getRiskGaugeSizing(isMobile, containerWidth);
-  const normalizedScore = normalizeRiskGaugeScore(score);
+  const displayScore = normalizeRiskGaugeScore(score);
   const valueLayout: RiskGaugeValueLayout = {
     bottomOffset: geometry.valueBottomOffset,
     fontSize:
-      normalizedScore === null
-        ? layout.unavailableFontSize
-        : layout.valueFontSize,
+      displayScore === null ? layout.unavailableFontSize : layout.valueFontSize,
     fontWeight: 800,
     lineHeight: 0.82,
   };
   const pointerAngle =
-    normalizedScore === null
+    displayScore === null
       ? null
       : RISK_GAUGE_TOTAL_ANGLE -
-        (normalizedScore / RISK_GAUGE_MAX_SCORE) * RISK_GAUGE_TOTAL_ANGLE;
+        (displayScore / RISK_GAUGE_MAX_SCORE) * RISK_GAUGE_TOTAL_ANGLE;
 
   return {
-    activeLevel: normalizedScore === null ? null : toRiskLevel(normalizedScore),
+    activeLevel: displayScore === null ? null : toRiskLevel(score),
+    displayScore,
     geometry,
     layout,
-    normalizedScore,
     pointerAngle,
     valueLayout,
   };
@@ -394,7 +393,7 @@ function buildRiskGaugeOptionFromMeasurements(
   labels: RiskGaugeLabels,
   measurements: RiskGaugeMeasurements,
 ): EChartsOption {
-  const { activeLevel, geometry, layout, normalizedScore, pointerAngle } =
+  const { activeLevel, displayScore, geometry, layout, pointerAngle } =
     measurements;
   const center = [geometry.width / 2, geometry.centerY];
 
@@ -446,7 +445,7 @@ function buildRiskGaugeOptionFromMeasurements(
         detail: {
           show: false,
         },
-        data: [{ value: normalizedScore ?? RISK_GAUGE_MIN_SCORE }],
+        data: [{ value: displayScore ?? RISK_GAUGE_MIN_SCORE }],
       },
       {
         type: "gauge",
@@ -504,7 +503,7 @@ function buildRiskGaugeOptionFromMeasurements(
         },
         data: [
           {
-            value: normalizedScore ?? RISK_GAUGE_MIN_SCORE,
+            value: displayScore ?? RISK_GAUGE_MIN_SCORE,
           },
         ],
       },
@@ -513,38 +512,34 @@ function buildRiskGaugeOptionFromMeasurements(
 }
 
 /**
- * Clamps a score into the supported gauge range or returns null when unavailable.
+ * Maps a raw risk score into the gauge display range or returns null when unavailable.
  */
 export function normalizeRiskGaugeScore(score: number): number | null {
-  if (!Number.isFinite(score)) {
-    return null;
-  }
-
-  return Math.min(Math.max(score, RISK_GAUGE_MIN_SCORE), RISK_GAUGE_MAX_SCORE);
+  return toRiskDisplayScore(score);
 }
 
 /**
- * Returns the active risk level for a clamped gauge score.
+ * Returns the active risk level for the raw gauge score.
  */
 export function getRiskGaugeActiveLevel(score: number): RiskLevel | null {
-  const normalizedScore = normalizeRiskGaugeScore(score);
+  const displayScore = normalizeRiskGaugeScore(score);
 
-  return normalizedScore === null ? null : toRiskLevel(normalizedScore);
+  return displayScore === null ? null : toRiskLevel(score);
 }
 
 /**
- * Maps the gauge score onto the semicircle needle angle.
+ * Maps the raw gauge score onto the semicircle needle angle.
  */
 export function getRiskGaugePointerAngle(score: number): number | null {
-  const normalizedScore = normalizeRiskGaugeScore(score);
+  const displayScore = normalizeRiskGaugeScore(score);
 
-  if (normalizedScore === null) {
+  if (displayScore === null) {
     return null;
   }
 
   return (
     RISK_GAUGE_TOTAL_ANGLE -
-    (normalizedScore / RISK_GAUGE_MAX_SCORE) * RISK_GAUGE_TOTAL_ANGLE
+    (displayScore / RISK_GAUGE_MAX_SCORE) * RISK_GAUGE_TOTAL_ANGLE
   );
 }
 
@@ -555,11 +550,7 @@ export function formatRiskGaugeValue(
   score: number,
   unavailableLabel: string,
 ): string {
-  const normalizedScore = normalizeRiskGaugeScore(score);
-
-  return normalizedScore === null
-    ? unavailableLabel
-    : normalizedScore.toFixed(1);
+  return Number.isFinite(score) ? score.toFixed(1) : unavailableLabel;
 }
 
 export function getRiskGaugeValueLayout(

--- a/frontend/src/pages/home/homeBootstrap.test.ts
+++ b/frontend/src/pages/home/homeBootstrap.test.ts
@@ -5,7 +5,7 @@ import type { PersistedHomeFilters } from "@/pages/home/browserState";
 import { resolveHomeBootstrapState } from "@/pages/home/homeBootstrap";
 
 describe("resolveHomeBootstrapState", () => {
-  it("prefers URL profile and filters over persisted values", () => {
+  it("keeps the default adult profile when URL state provides a younger profile", () => {
     expect(
       resolveHomeBootstrapState({
         hasUrlState: true,
@@ -23,7 +23,7 @@ describe("resolveHomeBootstrapState", () => {
       }),
     ).toEqual({
       channel: "shared",
-      profile: "AGE_10_13",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
       sport: SportType.Basketball,
       locationSearchInput: "Perth, AU",
       locationPrefillSource: "url",
@@ -31,7 +31,7 @@ describe("resolveHomeBootstrapState", () => {
     });
   });
 
-  it("uses persisted filters when no URL state is present", () => {
+  it("keeps the default adult profile when persisted filters store a younger profile", () => {
     expect(
       resolveHomeBootstrapState({
         hasUrlState: false,
@@ -49,7 +49,7 @@ describe("resolveHomeBootstrapState", () => {
       }),
     ).toEqual({
       channel: "direct",
-      profile: "AGE_14_17",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
       sport: SportType.Running,
       locationSearchInput: "Dampier, AU",
       locationPrefillSource: "persisted",

--- a/frontend/src/pages/home/homeBootstrap.ts
+++ b/frontend/src/pages/home/homeBootstrap.ts
@@ -35,23 +35,26 @@ export function resolveHomeBootstrapState({
   defaultProfile,
   defaultSport,
   defaultLocationLabel,
-  urlProfile,
   urlSport,
   urlLocation,
   persistedFilters,
 }: ResolveHomeBootstrapStateParams): HomeStoreBootstrapPayload {
   const channel: HomeChannel = hasUrlState ? "shared" : "direct";
 
+  const profile = defaultProfile;
+  /*
   let profile = defaultProfile;
+  */
   let sport = defaultSport;
   let locationSearchInput = "";
   let locationPrefillSource: LocationPrefillSource = "none";
 
   if (channel === "shared") {
+    /*
     if (urlProfile) {
       profile = urlProfile;
     }
-
+    */
     if (urlSport) {
       sport = urlSport;
     }
@@ -61,7 +64,9 @@ export function resolveHomeBootstrapState({
       locationPrefillSource = "url";
     }
   } else if (persistedFilters) {
+    /*
     profile = persistedFilters.profile ?? defaultProfile;
+    */
     sport = persistedFilters.sport;
     locationSearchInput = resolveInitialLocationLabel(persistedFilters.loc);
     if (locationSearchInput.length > 0) {


### PR DESCRIPTION
## Summary

This PR aligns the heat risk API contract and frontend score presentation with the updated `pythermalcomfort 3.9.2` behavior.

## Changes

- remove `wind_speed_effective_ms` from the backend and frontend heat risk contract
- stop applying sport-specific wind speed floors in the backend risk service and use only the height-scaled 1.1 m wind speed
- pin `pythermalcomfort` to `3.9.2` and update related backend documentation and tests
- update frontend risk level thresholds to match the raw model score scale
- remap raw risk scores onto the shared display coordinate system used by the forecast chart and gauge
- preserve raw risk scores in tooltip and value display while rendering the maximum model score at the high/extreme boundary

## Impact

- API consumers should no longer expect `wind_speed_effective_ms` in heat risk responses
- frontend charts and gauges now reflect the updated model thresholds without changing the raw values shown to users


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed `wind_speed_effective_ms` from forecast response payloads

* **Risk Level & Visualization Updates**
  * Modified wind speed calculation methodology for risk assessment
  * Adjusted risk level threshold mappings across the scale
  * Implemented remapped display scores for chart visualization
  * Updated risk gauge pointer positioning and chart coordinates
  * Refined low-risk forecast baseline positioning in charts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->