### PR TITLE
fix(frontend): add Open-Meteo attribution to footer

### DIFF
--- a/frontend/src/app/layout/SiteFooter.tsx
+++ b/frontend/src/app/layout/SiteFooter.tsx
@@ -8,7 +8,7 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { CONTENT_GAP, CONTENT_PADDING } from "@/config/uiLayout";
 import {
   PARAGRAPH_GAP,
@@ -20,6 +20,8 @@ const APP_VERSION = "1.2.2";
 const COPYRIGHT_YEAR = 2025;
 const REVIEW_YEAR = 2025;
 const FOOTER_LOGO_SLOT_HEIGHT = 50;
+const OPEN_METEO_URL = "https://open-meteo.com/";
+const CC_BY_4_URL = "https://creativecommons.org/licenses/by/4.0/";
 const FOOTER_TEXT_PROPS = {
   inherit: true,
   lh: STANDARD_TEXT_LINE_HEIGHT,
@@ -125,6 +127,31 @@ export function SiteFooter() {
               <Text {...FOOTER_TEXT_PROPS}>{t("footer.authors")}</Text>
               <Text {...FOOTER_TEXT_PROPS} fs="italic">
                 {t("footer.journal")}
+              </Text>
+              <Text {...FOOTER_TEXT_PROPS}>
+                <Trans
+                  i18nKey="footer.weatherAttribution"
+                  components={{
+                    openMeteoLink: (
+                      <Anchor
+                        inherit
+                        styles={footerLinkStyles}
+                        href={OPEN_METEO_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                      />
+                    ),
+                    licenceLink: (
+                      <Anchor
+                        inherit
+                        styles={footerLinkStyles}
+                        href={CC_BY_4_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                      />
+                    ),
+                  }}
+                />
               </Text>
               <Text {...FOOTER_TEXT_PROPS}>
                 {t("footer.copyright", { year: COPYRIGHT_YEAR })}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -23,7 +23,8 @@
     "version": "Version: {{version}}",
     "contactUs": "Contact Us",
     "usydLogoAlt": "University of Sydney logo",
-    "smaLogoAlt": "Sports Medicine Australia logo"
+    "smaLogoAlt": "Sports Medicine Australia logo",
+    "weatherAttribution": "Weather data by <openMeteoLink>Open-Meteo.com</openMeteoLink>. Processed for heat risk outputs. Licensed under <licenceLink>CC BY 4.0</licenceLink>."
   },
   "about": {
     "sections": [


### PR DESCRIPTION
Add linked Open-Meteo and CC BY 4.0 attribution in the site footer using i18n Trans markup.
<img width="732" height="494" alt="footer" src="https://github.com/user-attachments/assets/58951f4f-4e0a-46ae-9220-f221c0d49700" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Footer now displays weather attribution with links to data sources and open-source licensing information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FedericoTartarini/tool-sma-extreme-heat-policy/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->