### PR TITLE
fix: retry transient Open-Meteo failures and refine location search

### DIFF
--- a/backend/src/sma_extreme_heat_backend/clients/open_meteo.py
+++ b/backend/src/sma_extreme_heat_backend/clients/open_meteo.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import traceback
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -8,6 +11,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import httpx
 
 from sma_extreme_heat_backend.core.errors import WeatherProviderError
+
+LOGGER = logging.getLogger(__name__)
 
 _HOURLY_FIELDS: tuple[str, ...] = (
     "temperature_2m",
@@ -22,6 +27,9 @@ _EXPECTED_HOURLY_UNITS: dict[str, set[str]] = {
     "wind_speed_10m": {"m/s"},
     "direct_normal_irradiance": {"W/m²", "W/m^2"},
 }
+
+_DEFAULT_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (0.25, 1.0)
+_RETRYABLE_STATUS_CODES: set[int] = {408, 429}
 
 
 @dataclass(frozen=True)
@@ -204,14 +212,15 @@ class OpenMeteoClient:
         base_url: str,
         timeout_seconds: float,
         client: httpx.AsyncClient | None = None,
+        retry_backoff_seconds: tuple[float, ...] = _DEFAULT_RETRY_BACKOFF_SECONDS,
     ) -> None:
         """Create the client around a caller-supplied or owned HTTPX async client."""
 
+        self._base_url = base_url.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+        self._retry_backoff_seconds = retry_backoff_seconds
         self._owns_client = client is None
-        self._client = client or httpx.AsyncClient(
-            base_url=base_url.rstrip("/"),
-            timeout=timeout_seconds,
-        )
+        self._client = client or self._build_async_client()
 
     async def fetch_weather_forecast(
         self,
@@ -230,19 +239,130 @@ class OpenMeteoClient:
             "timezone": timezone_name,
         }
 
-        try:
-            response = await self._client.get("/forecast", params=params)
-            response.raise_for_status()
-            payload = response.json()
-        except httpx.HTTPError as exc:
-            raise WeatherProviderError() from exc
+        payload = await self._fetch_weather_payload(params=params)
 
         _validate_hourly_units(payload)
         points = _select_hourly_points(payload, requested_timezone_name=timezone_name)
         return WeatherForecast(points=points)
+
+    def _build_async_client(self) -> httpx.AsyncClient:
+        """Build an owned HTTPX client with the configured Open-Meteo settings."""
+
+        return httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout_seconds,
+        )
+
+    async def _fetch_weather_payload(self, *, params: dict[str, float | str]) -> dict[str, Any]:
+        """Fetch Open-Meteo JSON with bounded retries for transient upstream failures."""
+
+        max_attempts = len(self._retry_backoff_seconds) + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = await self._client.get("/forecast", params=params)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if not _is_retryable_status_code(status_code) or attempt == max_attempts:
+                    _log_weather_provider_failure(
+                        exc=exc,
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        status_code=status_code,
+                        will_retry=False,
+                    )
+                    raise WeatherProviderError() from exc
+
+                _log_weather_provider_failure(
+                    exc=exc,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    status_code=status_code,
+                    will_retry=True,
+                )
+            except httpx.RequestError as exc:
+                if attempt == max_attempts:
+                    _log_weather_provider_failure(
+                        exc=exc,
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        status_code=None,
+                        will_retry=False,
+                    )
+                    raise WeatherProviderError() from exc
+
+                _log_weather_provider_failure(
+                    exc=exc,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    status_code=None,
+                    will_retry=True,
+                )
+
+            await asyncio.sleep(self._retry_backoff_seconds[attempt - 1])
+
+        raise WeatherProviderError()
 
     async def aclose(self) -> None:
         """Close the owned HTTP client when the application shuts down."""
 
         if self._owns_client:
             await self._client.aclose()
+
+
+def _is_retryable_status_code(status_code: int) -> bool:
+    """Return whether an upstream HTTP status is likely transient."""
+
+    return status_code in _RETRYABLE_STATUS_CODES or status_code >= 500
+
+
+def _safe_exception_message(exc: httpx.HTTPError) -> str:
+    """Return an exception message without the full Open-Meteo URL/query string."""
+
+    message = str(exc)
+    return _redact_exception_request_url(exc=exc, text=message)
+
+
+def _safe_exception_traceback(exc: httpx.HTTPError) -> str:
+    """Return a traceback string without the full Open-Meteo URL/query string."""
+
+    formatted = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    return _redact_exception_request_url(exc=exc, text=formatted)
+
+
+def _redact_exception_request_url(*, exc: httpx.HTTPError, text: str) -> str:
+    """Redact the provider request URL from text derived from an HTTPX exception."""
+
+    request = getattr(exc, "request", None)
+    if request is not None:
+        return text.replace(str(request.url), "<open-meteo-url-redacted>")
+    return text
+
+
+def _log_weather_provider_failure(
+    *,
+    exc: httpx.HTTPError,
+    attempt: int,
+    max_attempts: int,
+    status_code: int | None,
+    will_retry: bool,
+) -> None:
+    """Log Open-Meteo failures without leaking precise request coordinates."""
+
+    log_method = LOGGER.warning if will_retry else LOGGER.error
+    log_extra: dict[str, Any] = {
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "exception_type": type(exc).__name__,
+        "exception_message": _safe_exception_message(exc),
+        "status_code": status_code,
+        "will_retry": will_retry,
+    }
+    if not will_retry:
+        log_extra["exception_traceback"] = _safe_exception_traceback(exc)
+
+    log_method(
+        "Open-Meteo request failed",
+        extra=log_extra,
+    )

--- a/backend/tests/clients/test_open_meteo.py
+++ b/backend/tests/clients/test_open_meteo.py
@@ -69,8 +69,180 @@ def _build_client(handler) -> tuple[OpenMeteoClient, httpx.AsyncClient]:
         base_url="https://api.open-meteo.com/v1",
         timeout_seconds=10.0,
         client=mock_client,
+        retry_backoff_seconds=(0.0, 0.0),
     )
     return client, mock_client
+
+
+async def test_fetch_weather_forecast_retries_connect_error_then_returns_points() -> None:
+    """Transient request failures should be retried before surfacing a provider error."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    payload = _hourly_payload(
+        times=[now],
+        tdb=[31.0],
+        rh=[62.0],
+        wind=[1.5],
+        radiation=[720.0],
+    )
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ConnectError("Open-Meteo connection failed", request=request)
+        return httpx.Response(status_code=200, json=payload)
+
+    client, mock_client = _build_client(handler)
+
+    weather = await client.fetch_weather_forecast(
+        latitude=-33.847,
+        longitude=151.067,
+        timezone_name="UTC",
+    )
+    await mock_client.aclose()
+
+    assert calls == 2
+    assert [point.time_utc for point in weather.points] == [now]
+
+
+async def test_fetch_weather_forecast_keeps_owned_client_open_after_request_error() -> None:
+    """Owned clients should not be closed and rebuilt during request-error retries."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    payload = _hourly_payload(
+        times=[now],
+        tdb=[31.0],
+        rh=[62.0],
+        wind=[1.5],
+        radiation=[720.0],
+    )
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ConnectError("Open-Meteo connection failed", request=request)
+        return httpx.Response(status_code=200, json=payload)
+
+    owned_client = httpx.AsyncClient(
+        base_url="https://api.open-meteo.com/v1",
+        transport=httpx.MockTransport(handler),
+    )
+    client = OpenMeteoClient(
+        base_url="https://api.open-meteo.com/v1",
+        timeout_seconds=10.0,
+        retry_backoff_seconds=(0.0, 0.0),
+    )
+    await client._client.aclose()
+    client._client = owned_client
+
+    try:
+        weather = await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
+
+        assert calls == 2
+        assert client._client is owned_client
+        assert not owned_client.is_closed
+        assert [point.time_utc for point in weather.points] == [now]
+    finally:
+        await client.aclose()
+
+    assert owned_client.is_closed
+
+
+async def test_fetch_weather_forecast_retries_http_500_then_returns_points() -> None:
+    """Transient upstream server errors should be retried."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    payload = _hourly_payload(
+        times=[now],
+        tdb=[31.0],
+        rh=[62.0],
+        wind=[1.5],
+        radiation=[720.0],
+    )
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(status_code=500)
+        return httpx.Response(status_code=200, json=payload)
+
+    client, mock_client = _build_client(handler)
+
+    weather = await client.fetch_weather_forecast(
+        latitude=-33.847,
+        longitude=151.067,
+        timezone_name="UTC",
+    )
+    await mock_client.aclose()
+
+    assert calls == 2
+    assert [point.time_utc for point in weather.points] == [now]
+
+
+async def test_fetch_weather_forecast_raises_after_retryable_http_429_attempts() -> None:
+    """Retryable upstream statuses should eventually surface the stable provider error."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status_code=429)
+
+    client, mock_client = _build_client(handler)
+
+    try:
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
+    except WeatherProviderError as exc:
+        assert exc.detail == "Weather provider unavailable"
+    else:
+        raise AssertionError("Expected WeatherProviderError after retryable 429 attempts")
+    finally:
+        await mock_client.aclose()
+
+    assert calls == 3
+
+
+async def test_fetch_weather_forecast_does_not_retry_http_400() -> None:
+    """Non-retryable upstream client errors should fail after the first attempt."""
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status_code=400)
+
+    client, mock_client = _build_client(handler)
+
+    try:
+        await client.fetch_weather_forecast(
+            latitude=-33.847,
+            longitude=151.067,
+            timezone_name="UTC",
+        )
+    except WeatherProviderError as exc:
+        assert exc.detail == "Weather provider unavailable"
+    else:
+        raise AssertionError("Expected WeatherProviderError for non-retryable 400")
+    finally:
+        await mock_client.aclose()
+
+    assert calls == 1
 
 
 async def test_fetch_weather_forecast_returns_hourly_points_from_now_minus_1h() -> None:
@@ -175,8 +347,11 @@ async def test_fetch_weather_forecast_rejects_invalid_temperature_unit() -> None
         radiation=[720.0],
         units_override={"temperature_2m": "°F"},
     )
+    calls = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
         return httpx.Response(status_code=200, json=payload)
 
     client, mock_client = _build_client(handler)
@@ -193,6 +368,8 @@ async def test_fetch_weather_forecast_rejects_invalid_temperature_unit() -> None
         raise AssertionError("Expected WeatherProviderError for invalid temperature unit")
     finally:
         await mock_client.aclose()
+
+    assert calls == 1
 
 
 async def test_fetch_weather_forecast_rejects_invalid_direct_normal_irradiance_unit() -> None:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,7 @@ Import rules:
 - Client state lives in `src/store/homeStore.ts` (Zustand).
 - Uses the official `zustand` npm package.
 - Server state uses React Query (`@tanstack/react-query`).
-- Location search uses Mapbox Search Box `suggest` with neighborhood, locality, place, and city types (`locality,neighborhood,place,city`); selecting a suggestion triggers Mapbox `retrieve` in frontend to resolve coordinates.
+- Location search uses Mapbox Search Box `suggest` with neighborhood, locality, place, and city types (`neighborhood,locality,place,city`); selecting a suggestion triggers Mapbox `retrieve` in frontend to resolve coordinates. City-state and special-place results without a country context fall back to their place/name so results such as Singapore remain selectable.
 - Location labels shown in the input, dropdown, URL, and local persistence use readable `Name, Region, Country` text, for example `Auburn, New South Wales, Australia`.
 - The visible location dropdown is capped to the first 3 unique Mapbox suggestions after dedupe by name, region, and country.
 - Prefilled location labels restored from shared URL (`loc`) or local persistence automatically attempt `suggest + retrieve` once using exact normalized canonical label matching; old or non-canonical labels show Mapbox candidates for manual selection when suggestions are available.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -86,7 +86,7 @@ Import rules:
 - Location search uses Mapbox Search Box `suggest` with neighborhood, locality, place, and city types (`locality,neighborhood,place,city`); selecting a suggestion triggers Mapbox `retrieve` in frontend to resolve coordinates.
 - Location labels shown in the input, dropdown, URL, and local persistence use readable `Name, Region, Country` text, for example `Auburn, New South Wales, Australia`.
 - The visible location dropdown is capped to the first 3 unique Mapbox suggestions after dedupe by name, region, and country.
-- Prefilled location labels restored from shared URL (`loc`) or local persistence automatically attempt `suggest + retrieve` once using exact normalized canonical label matching.
+- Prefilled location labels restored from shared URL (`loc`) or local persistence automatically attempt `suggest + retrieve` once using exact normalized canonical label matching; old or non-canonical labels show Mapbox candidates for manual selection when suggestions are available.
 - Risk API request sends `sport + latitude + longitude + profile` (no Mapbox identifiers).
 - Risk API response returns a non-empty `forecast[]` plus a nested `request` block containing `sport`, `profile`, and `location`; backend defines `forecast[0]` as the earliest complete forecast point, each forecast row includes both `time_utc` and `time_local`, and frontend derives the current risk from `forecast[0]` while grouping chart days from `time_local`.
 - Risk is fetched automatically when:

--- a/frontend/src/api/mapboxSuggest.test.ts
+++ b/frontend/src/api/mapboxSuggest.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { suggestLocations } from "@/api/mapboxSuggest";
 
+const SUPPORTED_LOCATION_TYPES = "neighborhood,locality,place,city";
+
 describe("suggestLocations", () => {
   const fetchMock = vi.fn<typeof fetch>();
 
@@ -42,13 +44,13 @@ describe("suggestLocations", () => {
       query: "Auburn",
       accessToken: "token",
       sessionToken: "session",
-      types: "locality,neighborhood,place,city",
+      types: SUPPORTED_LOCATION_TYPES,
       language: "en",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
-      "types=locality%2Cneighborhood%2Cplace%2Ccity",
+      "types=neighborhood%2Clocality%2Cplace%2Ccity",
     );
     expect(suggestions).toEqual([
       {
@@ -89,7 +91,7 @@ describe("suggestLocations", () => {
       query: "Surry Hills",
       accessToken: "token",
       sessionToken: "session",
-      types: "locality,neighborhood,place,city",
+      types: SUPPORTED_LOCATION_TYPES,
     });
 
     expect(suggestions).toEqual([
@@ -124,7 +126,7 @@ describe("suggestLocations", () => {
       query: "Darwin",
       accessToken: "token",
       sessionToken: "session",
-      types: "locality,neighborhood,place,city",
+      types: SUPPORTED_LOCATION_TYPES,
     });
 
     expect(suggestions[0]?.displayLabel).toBe(
@@ -157,11 +159,147 @@ describe("suggestLocations", () => {
       query: "Singapore",
       accessToken: "token",
       sessionToken: "session",
-      types: "locality,neighborhood,place,city",
+      types: SUPPORTED_LOCATION_TYPES,
     });
 
     expect(suggestions[0]?.displayLabel).toBe("Singapore, Singapore");
     expect(suggestions[0]).not.toHaveProperty("regionName");
+  });
+
+  it("uses place context as the country fallback for city-state results", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          suggestions: [
+            {
+              mapbox_id: "place-hong-kong",
+              feature_type: "place",
+              name: "Hong Kong",
+              context: {
+                place: { name: "Hong Kong" },
+              },
+            },
+            {
+              mapbox_id: "locality-singapore",
+              feature_type: "locality",
+              name: "Singapore",
+              context: {
+                place: { name: "Singapore" },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const suggestions = await suggestLocations({
+      query: "Hong Kong",
+      accessToken: "token",
+      sessionToken: "session",
+      types: SUPPORTED_LOCATION_TYPES,
+    });
+
+    expect(suggestions).toEqual([
+      {
+        id: "place-hong-kong",
+        displayLabel: "Hong Kong, Hong Kong",
+        name: "Hong Kong",
+        countryName: "Hong Kong",
+        mapboxId: "place-hong-kong",
+        sessionToken: "session",
+      },
+      {
+        id: "locality-singapore",
+        displayLabel: "Singapore, Singapore",
+        name: "Singapore",
+        countryName: "Singapore",
+        mapboxId: "locality-singapore",
+        sessionToken: "session",
+      },
+    ]);
+    expect(suggestions[0]).not.toHaveProperty("countryCode");
+    expect(suggestions[1]).not.toHaveProperty("countryCode");
+  });
+
+  it("uses the suggestion name as the country fallback for whole-place features", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          suggestions: [
+            {
+              mapbox_id: "city-singapore",
+              feature_type: "city",
+              name: "Singapore",
+              context: {},
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const suggestions = await suggestLocations({
+      query: "Singapore",
+      accessToken: "token",
+      sessionToken: "session",
+      types: SUPPORTED_LOCATION_TYPES,
+    });
+
+    expect(suggestions).toEqual([
+      expect.objectContaining({
+        id: "city-singapore",
+        displayLabel: "Singapore, Singapore",
+        countryName: "Singapore",
+      }),
+    ]);
+    expect(suggestions[0]).not.toHaveProperty("countryCode");
+  });
+
+  it("drops larger administrative results", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          suggestions: [
+            {
+              mapbox_id: "district-greater-sydney",
+              feature_type: "district",
+              name: "Greater Sydney",
+              context: {
+                country: { name: "Australia", country_code: "AU" },
+                region: { name: "New South Wales" },
+              },
+            },
+            {
+              mapbox_id: "region-new-south-wales",
+              feature_type: "region",
+              name: "New South Wales",
+              context: {
+                country: { name: "Australia", country_code: "AU" },
+              },
+            },
+            {
+              mapbox_id: "country-hong-kong",
+              feature_type: "country",
+              name: "Hong Kong",
+              context: {
+                country: { name: "Hong Kong", country_code: "HK" },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const suggestions = await suggestLocations({
+      query: "Hong Kong",
+      accessToken: "token",
+      sessionToken: "session",
+      types: SUPPORTED_LOCATION_TYPES,
+    });
+
+    expect(suggestions).toEqual([]);
   });
 
   it("drops results outside supported weather location types or without readable identity", async () => {
@@ -189,30 +327,6 @@ describe("suggestLocations", () => {
               mapbox_id: "postcode-result",
               feature_type: "postcode",
               name: "2000",
-              context: {
-                country: { name: "Australia", country_code: "AU" },
-              },
-            },
-            {
-              mapbox_id: "district-result",
-              feature_type: "district",
-              name: "Greater Sydney",
-              context: {
-                country: { name: "Australia", country_code: "AU" },
-              },
-            },
-            {
-              mapbox_id: "region-result",
-              feature_type: "region",
-              name: "New South Wales",
-              context: {
-                country: { name: "Australia", country_code: "AU" },
-              },
-            },
-            {
-              mapbox_id: "country-result",
-              feature_type: "country",
-              name: "Australia",
               context: {
                 country: { name: "Australia", country_code: "AU" },
               },
@@ -250,7 +364,7 @@ describe("suggestLocations", () => {
       query: "Auburn",
       accessToken: "token",
       sessionToken: "session",
-      types: "locality,neighborhood,place,city",
+      types: SUPPORTED_LOCATION_TYPES,
     });
 
     expect(suggestions).toEqual([]);
@@ -264,7 +378,7 @@ describe("suggestLocations", () => {
         query: "Darwin",
         accessToken: "token",
         sessionToken: "session",
-        types: "locality,neighborhood,place,city",
+        types: SUPPORTED_LOCATION_TYPES,
       }),
     ).rejects.toThrow("Mapbox suggest failed with HTTP 502");
   });

--- a/frontend/src/api/mapboxSuggest.test.ts
+++ b/frontend/src/api/mapboxSuggest.test.ts
@@ -222,6 +222,43 @@ describe("suggestLocations", () => {
     expect(suggestions[1]).not.toHaveProperty("countryCode");
   });
 
+  it("does not use broader place context as the country fallback for local results", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          suggestions: [
+            {
+              mapbox_id: "locality-fortitude-valley",
+              feature_type: "locality",
+              name: "Fortitude Valley",
+              context: {
+                place: { name: "Brisbane" },
+              },
+            },
+            {
+              mapbox_id: "neighborhood-south-bank",
+              feature_type: "neighborhood",
+              name: "South Bank",
+              context: {
+                place: { name: "Brisbane" },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const suggestions = await suggestLocations({
+      query: "Brisbane",
+      accessToken: "token",
+      sessionToken: "session",
+      types: SUPPORTED_LOCATION_TYPES,
+    });
+
+    expect(suggestions).toEqual([]);
+  });
+
   it("uses the suggestion name as the country fallback for whole-place features", async () => {
     fetchMock.mockResolvedValue(
       new Response(

--- a/frontend/src/api/mapboxSuggest.ts
+++ b/frontend/src/api/mapboxSuggest.ts
@@ -18,6 +18,10 @@ interface MapboxSuggestItem {
 
 type UnknownRecord = Record<string, unknown>;
 const LOCATION_SUGGEST_TYPE_SET = new Set<string>(LOCATION_SUGGEST_TYPES);
+const COUNTRY_NAME_FALLBACK_FEATURE_TYPE_SET = new Set<string>([
+  "place",
+  "city",
+]);
 
 export interface MapboxSuggestParams {
   query: string;
@@ -69,6 +73,28 @@ function toCountryCode(context: unknown): string {
   return toTrimmedString(countryEntry.country_code).toUpperCase();
 }
 
+function toCountryName(params: {
+  context: unknown;
+  fallbackName: string;
+  featureType: unknown;
+}): string {
+  const { context, fallbackName, featureType } = params;
+  const countryName = toContextName(context, "country");
+  if (countryName) {
+    return countryName;
+  }
+
+  const placeName = toContextName(context, "place");
+  if (placeName) {
+    return placeName;
+  }
+
+  const normalizedFeatureType = toTrimmedString(featureType);
+  return COUNTRY_NAME_FALLBACK_FEATURE_TYPE_SET.has(normalizedFeatureType)
+    ? fallbackName
+    : "";
+}
+
 function isSupportedFeatureType(value: unknown): boolean {
   const normalizedValue = toTrimmedString(value);
   return LOCATION_SUGGEST_TYPE_SET.has(normalizedValue);
@@ -92,7 +118,11 @@ function toLocationSuggestion(
   const mapboxId = suggestion.mapbox_id;
   const name = toTrimmedString(suggestion.name_preferred ?? suggestion.name);
   const regionName = toContextName(suggestion.context, "region");
-  const countryName = toContextName(suggestion.context, "country");
+  const countryName = toCountryName({
+    context: suggestion.context,
+    fallbackName: name,
+    featureType: suggestion.feature_type,
+  });
   const countryCode = toCountryCode(suggestion.context);
 
   if (
@@ -148,7 +178,7 @@ function toSuggestQueryString({
 }
 
 /**
- * Calls Mapbox Search Box `suggest` API and maps neighborhood, locality, place, and city results.
+ * Calls Mapbox Search Box `suggest` API and maps supported weather location results.
  */
 export async function suggestLocations({
   query,

--- a/frontend/src/api/mapboxSuggest.ts
+++ b/frontend/src/api/mapboxSuggest.ts
@@ -84,12 +84,18 @@ function toCountryName(params: {
     return countryName;
   }
 
+  const normalizedFeatureType = toTrimmedString(featureType);
   const placeName = toContextName(context, "place");
-  if (placeName) {
+  const normalizedPlaceName = toTrimmedString(placeName);
+  const normalizedFallbackName = toTrimmedString(fallbackName);
+  if (
+    normalizedPlaceName &&
+    (normalizedPlaceName === normalizedFallbackName ||
+      COUNTRY_NAME_FALLBACK_FEATURE_TYPE_SET.has(normalizedFeatureType))
+  ) {
     return placeName;
   }
 
-  const normalizedFeatureType = toTrimmedString(featureType);
   return COUNTRY_NAME_FALLBACK_FEATURE_TYPE_SET.has(normalizedFeatureType)
     ? fallbackName
     : "";

--- a/frontend/src/components/home/FiltersSection.tsx
+++ b/frontend/src/components/home/FiltersSection.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   useCombobox,
 } from "@mantine/core";
-import { type MouseEvent, useMemo, useState } from "react";
+import { type MouseEvent, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   isSportType,
@@ -85,6 +85,7 @@ export function FiltersSection() {
     locationSearchInput,
     locationSuggestions,
     isSuggestLoading,
+    shouldOpenLocationDropdown,
     onLocationSearchInputChange,
     onLocationOptionSubmit,
   } = useHomeLocationSuggest();
@@ -102,6 +103,16 @@ export function FiltersSection() {
       {suggestion.displayLabel}
     </Combobox.Option>
   ));
+
+  useEffect(() => {
+    if (shouldOpenLocationDropdown && shouldRenderLocationDropdown) {
+      locationCombobox.openDropdown();
+    }
+  }, [
+    locationCombobox,
+    shouldOpenLocationDropdown,
+    shouldRenderLocationDropdown,
+  ]);
 
   /*
   const handleProfileChange = (value: string | null) => {

--- a/frontend/src/domain/locationSearch.test.ts
+++ b/frontend/src/domain/locationSearch.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeLocationSearchText,
   prepareLocationSuggestions,
   resolvePrefilledLocationSuggestion,
+  shouldOpenPrefilledLocationDropdown,
 } from "@/domain/locationSearch";
 
 function createSuggestion(
@@ -213,5 +214,89 @@ describe("resolvePrefilledLocationSuggestion", () => {
         prefillSource: "default",
       }),
     ).toBe(suggestion);
+  });
+});
+
+describe("shouldOpenPrefilledLocationDropdown", () => {
+  it.each(["url", "persisted"] as const)(
+    "opens candidates for non-canonical %s prefill values",
+    (prefillSource) => {
+      const suggestion = createSuggestion({
+        id: "darwin",
+        displayLabel: "Darwin, Northern Territory, Australia",
+        name: "Darwin",
+        regionName: "Northern Territory",
+      });
+
+      expect(
+        shouldOpenPrefilledLocationDropdown({
+          suggestions: [suggestion],
+          visibleSuggestions: [suggestion],
+          value: "Darwin, AU",
+          prefillSource,
+          isSuggestSuccess: true,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["url", "persisted"] as const)(
+    "does not open candidates for exact %s prefill matches",
+    (prefillSource) => {
+      const suggestion = createSuggestion({
+        id: "auburn",
+        displayLabel: "Auburn, New South Wales, Australia",
+        name: "Auburn",
+        regionName: "New South Wales",
+      });
+
+      expect(
+        shouldOpenPrefilledLocationDropdown({
+          suggestions: [suggestion],
+          visibleSuggestions: [suggestion],
+          value: "Auburn, New South Wales, Australia",
+          prefillSource,
+          isSuggestSuccess: true,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("does not open candidates for default prefill fallback", () => {
+    const suggestion = createSuggestion({
+      id: "sydney",
+      displayLabel: "Sydney, New South Wales, Australia",
+      name: "Sydney",
+      regionName: "New South Wales",
+    });
+
+    expect(
+      shouldOpenPrefilledLocationDropdown({
+        suggestions: [suggestion],
+        visibleSuggestions: [suggestion],
+        value: "Default Sydney label",
+        prefillSource: "default",
+        isSuggestSuccess: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not open candidates when no visible suggestions are available", () => {
+    const suggestion = createSuggestion({
+      id: "darwin",
+      displayLabel: "Darwin, Northern Territory, Australia",
+      name: "Darwin",
+      regionName: "Northern Territory",
+    });
+
+    expect(
+      shouldOpenPrefilledLocationDropdown({
+        suggestions: [suggestion],
+        visibleSuggestions: [],
+        value: "Darwin, AU",
+        prefillSource: "url",
+        isSuggestSuccess: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/domain/locationSearch.test.ts
+++ b/frontend/src/domain/locationSearch.test.ts
@@ -5,6 +5,7 @@ import {
   prepareLocationSuggestions,
   resolvePrefilledLocationSuggestion,
   shouldOpenPrefilledLocationDropdown,
+  toPrefilledLocationSuggestQuery,
 } from "@/domain/locationSearch";
 
 function createSuggestion(
@@ -34,6 +35,22 @@ describe("normalizeLocationSearchText", () => {
     expect(normalizeLocationSearchText(" Auburn, NSW / AU ")).toBe(
       "auburn nsw au",
     );
+  });
+});
+
+describe("toPrefilledLocationSuggestQuery", () => {
+  it.each([
+    ["Hong Kong, Hong Kong", "Hong Kong"],
+    ["Singapore, Singapore", "Singapore"],
+    ["  Hong Kong , hong   kong  ", "Hong Kong"],
+  ])("simplifies repeated location labels from %s", (value, expected) => {
+    expect(toPrefilledLocationSuggestQuery(value)).toBe(expected);
+  });
+
+  it("keeps non-repeated location labels unchanged", () => {
+    expect(
+      toPrefilledLocationSuggestQuery("Perth, Western Australia, Australia"),
+    ).toBe("Perth, Western Australia, Australia");
   });
 });
 
@@ -136,6 +153,27 @@ describe("resolvePrefilledLocationSuggestion", () => {
         resolvePrefilledLocationSuggestion({
           suggestions: [suggestion],
           value: "Auburn, New South Wales, Australia",
+          prefillSource,
+        }),
+      ).toBe(suggestion);
+    },
+  );
+
+  it.each(["url", "persisted"] as const)(
+    "matches repeated %s prefill labels through the simplified suggest query",
+    (prefillSource) => {
+      const suggestion = createSuggestion({
+        id: "hong-kong",
+        displayLabel: "Hong Kong",
+        name: "Hong Kong",
+        countryName: "Hong Kong",
+        countryCode: "HK",
+      });
+
+      expect(
+        resolvePrefilledLocationSuggestion({
+          suggestions: [suggestion],
+          value: "Hong Kong, Hong Kong",
           prefillSource,
         }),
       ).toBe(suggestion);

--- a/frontend/src/domain/locationSearch.ts
+++ b/frontend/src/domain/locationSearch.ts
@@ -1,8 +1,8 @@
 import type { LocationSuggestion } from "@/domain/location";
 
 export const LOCATION_SUGGEST_TYPES = [
-  "locality",
   "neighborhood",
+  "locality",
   "place",
   "city",
 ] as const;
@@ -15,6 +15,19 @@ export interface PreparedLocationSuggestions {
 }
 
 export type LocationPrefillSource = "url" | "persisted" | "default" | "none";
+
+function isRestoredPrefillSource(
+  prefillSource: LocationPrefillSource,
+): boolean {
+  return prefillSource === "url" || prefillSource === "persisted";
+}
+
+function toLocationLabelParts(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim().replace(/\s+/g, " "))
+    .filter(Boolean);
+}
 
 function toLocationIdentityKey(suggestion: LocationSuggestion): string {
   return [suggestion.name, suggestion.regionName ?? "", suggestion.countryName]
@@ -79,6 +92,21 @@ export function findExactNormalizedSuggestion(
   );
 }
 
+export function toPrefilledLocationSuggestQuery(value: string): string {
+  const trimmedValue = value.trim();
+  const parts = toLocationLabelParts(trimmedValue);
+
+  if (
+    parts.length === 2 &&
+    normalizeLocationSearchText(parts[0]) ===
+      normalizeLocationSearchText(parts[1])
+  ) {
+    return parts[0];
+  }
+
+  return trimmedValue;
+}
+
 export function resolvePrefilledLocationSuggestion(params: {
   suggestions: LocationSuggestion[];
   value: string;
@@ -89,6 +117,25 @@ export function resolvePrefilledLocationSuggestion(params: {
 
   if (exactSuggestion) {
     return exactSuggestion;
+  }
+
+  const suggestQuery = isRestoredPrefillSource(prefillSource)
+    ? toPrefilledLocationSuggestQuery(value)
+    : "";
+  const shouldTrySuggestQuery =
+    suggestQuery.length > 0 &&
+    normalizeLocationSearchText(suggestQuery) !==
+      normalizeLocationSearchText(value);
+
+  if (shouldTrySuggestQuery) {
+    const suggestQueryMatch = findExactNormalizedSuggestion(
+      suggestions,
+      suggestQuery,
+    );
+
+    if (suggestQueryMatch) {
+      return suggestQueryMatch;
+    }
   }
 
   return prefillSource === "default" ? (suggestions[0] ?? null) : null;

--- a/frontend/src/domain/locationSearch.ts
+++ b/frontend/src/domain/locationSearch.ts
@@ -14,7 +14,7 @@ export interface PreparedLocationSuggestions {
   visibleSuggestions: LocationSuggestion[];
 }
 
-type LocationPrefillSource = "url" | "persisted" | "default" | "none";
+export type LocationPrefillSource = "url" | "persisted" | "default" | "none";
 
 function toLocationIdentityKey(suggestion: LocationSuggestion): string {
   return [suggestion.name, suggestion.regionName ?? "", suggestion.countryName]
@@ -92,4 +92,33 @@ export function resolvePrefilledLocationSuggestion(params: {
   }
 
   return prefillSource === "default" ? (suggestions[0] ?? null) : null;
+}
+
+/**
+ * Determines whether unmatched URL/storage prefill values should reveal manual choices.
+ */
+export function shouldOpenPrefilledLocationDropdown(params: {
+  suggestions: LocationSuggestion[];
+  visibleSuggestions: LocationSuggestion[];
+  value: string;
+  prefillSource: LocationPrefillSource;
+  isSuggestSuccess: boolean;
+}): boolean {
+  const {
+    suggestions,
+    visibleSuggestions,
+    value,
+    prefillSource,
+    isSuggestSuccess,
+  } = params;
+
+  if (
+    !isSuggestSuccess ||
+    visibleSuggestions.length === 0 ||
+    (prefillSource !== "url" && prefillSource !== "persisted")
+  ) {
+    return false;
+  }
+
+  return findExactNormalizedSuggestion(suggestions, value) === null;
 }

--- a/frontend/src/hooks/useHomeLocationSuggest.ts
+++ b/frontend/src/hooks/useHomeLocationSuggest.ts
@@ -9,10 +9,11 @@ import {
   LOCATION_SUGGEST_TYPES_PARAM,
   prepareLocationSuggestions,
   resolvePrefilledLocationSuggestion,
+  shouldOpenPrefilledLocationDropdown,
 } from "@/domain/locationSearch";
 import { useHomeStore } from "@/store/homeStore";
 
-const MIN_LOCATION_QUERY_LENGTH = 3;
+const MIN_LOCATION_QUERY_LENGTH = 2;
 const SUGGEST_DEBOUNCE_MS = 800;
 const EMPTY_SUGGESTIONS: LocationSuggestion[] = [];
 
@@ -22,6 +23,7 @@ interface UseHomeLocationSuggestResult {
   locationSearchInput: string;
   locationSuggestions: LocationSuggestion[];
   isSuggestLoading: boolean;
+  shouldOpenLocationDropdown: boolean;
   suggestErrorReason: LocationSuggestErrorReason | null;
   onLocationSearchInputChange: (value: string) => void;
   onLocationOptionSubmit: (suggestionId: string) => void;
@@ -296,6 +298,15 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     isSuggestSuccess: suggestQuery.isSuccess,
     suggestionCount: dedupedSuggestions.length,
   });
+  const shouldOpenLocationDropdown =
+    hasPrefilledNotMatched &&
+    shouldOpenPrefilledLocationDropdown({
+      suggestions: dedupedSuggestions,
+      visibleSuggestions,
+      value: query,
+      prefillSource: locationPrefillSource,
+      isSuggestSuccess: suggestQuery.isSuccess,
+    });
 
   const onLocationSearchInputChange = (value: string) => {
     if (hasRetrieveError) {
@@ -333,6 +344,7 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     locationSearchInput,
     locationSuggestions: visibleSuggestions,
     isSuggestLoading: shouldSuggest && suggestQuery.isFetching,
+    shouldOpenLocationDropdown,
     suggestErrorReason,
     onLocationSearchInputChange,
     onLocationOptionSubmit,

--- a/frontend/src/hooks/useHomeLocationSuggest.ts
+++ b/frontend/src/hooks/useHomeLocationSuggest.ts
@@ -10,6 +10,7 @@ import {
   prepareLocationSuggestions,
   resolvePrefilledLocationSuggestion,
   shouldOpenPrefilledLocationDropdown,
+  toPrefilledLocationSuggestQuery,
 } from "@/domain/locationSearch";
 import { useHomeStore } from "@/store/homeStore";
 
@@ -194,8 +195,14 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
   const selectedLocationValue = selectedLocation?.displayLabel.trim() ?? "";
   const language = useMemo(() => getLanguagePreference(), []);
   const [debouncedQuery] = useDebouncedValue(query, SUGGEST_DEBOUNCE_MS);
-  const queryForRequest = debouncedQuery.trim();
-  const hasDebounced = queryForRequest === query;
+  const debouncedQueryValue = debouncedQuery.trim();
+  const shouldUsePrefilledSuggestQuery =
+    shouldAutoResolvePrefilledLocation &&
+    (locationPrefillSource === "url" || locationPrefillSource === "persisted");
+  const queryForRequest = shouldUsePrefilledSuggestQuery
+    ? toPrefilledLocationSuggestQuery(debouncedQueryValue)
+    : debouncedQueryValue;
+  const hasDebounced = debouncedQueryValue === query;
 
   const shouldSuggest = shouldRunSuggestQuery({
     hasMapboxToken,

--- a/frontend/src/hooks/useHomeLocationSuggest.ts
+++ b/frontend/src/hooks/useHomeLocationSuggest.ts
@@ -169,25 +169,28 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     (state) => state.locationSearchInput,
   );
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
-  const shouldAutoResolvePrefilledLocation = useHomeStore(
-    (state) => state.shouldAutoResolvePrefilledLocation,
+  const prefilledLocationResolveState = useHomeStore(
+    (state) => state.prefilledLocationResolveState,
   );
   const locationPrefillSource = useHomeStore(
     (state) => state.locationPrefillSource,
-  );
-  const hasPrefilledNotMatched = useHomeStore(
-    (state) => state.hasPrefilledLocationNotMatched,
   );
   const sessionToken = useHomeStore((state) => state.locationSessionToken);
   const setLocationSearchInput = useHomeStore(
     (state) => state.setLocationSearchInput,
   );
   const selectLocation = useHomeStore((state) => state.selectLocation);
-  const consumeAutoResolvePrefilledLocation = useHomeStore(
-    (state) => state.consumeAutoResolvePrefilledLocation,
+  const startPrefilledLocationResolve = useHomeStore(
+    (state) => state.startPrefilledLocationResolve,
   );
-  const setHasPrefilledLocationNotMatched = useHomeStore(
-    (state) => state.setHasPrefilledLocationNotMatched,
+  const finishPrefilledLocationResolve = useHomeStore(
+    (state) => state.finishPrefilledLocationResolve,
+  );
+  const markPrefilledLocationNotFound = useHomeStore(
+    (state) => state.markPrefilledLocationNotFound,
+  );
+  const markPrefilledLocationNotMatched = useHomeStore(
+    (state) => state.markPrefilledLocationNotMatched,
   );
   const [hasRetrieveError, setHasRetrieveError] = useState(false);
 
@@ -196,9 +199,16 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
   const language = useMemo(() => getLanguagePreference(), []);
   const [debouncedQuery] = useDebouncedValue(query, SUGGEST_DEBOUNCE_MS);
   const debouncedQueryValue = debouncedQuery.trim();
+  const hasRestoredPrefillSource =
+    locationPrefillSource === "url" || locationPrefillSource === "persisted";
+  const isPrefilledLocationResolvePending =
+    prefilledLocationResolveState === "pending";
+  const hasActivePrefilledLocationResolve =
+    prefilledLocationResolveState !== "idle";
+  const hasPrefilledNotMatched =
+    prefilledLocationResolveState === "not_matched";
   const shouldUsePrefilledSuggestQuery =
-    shouldAutoResolvePrefilledLocation &&
-    (locationPrefillSource === "url" || locationPrefillSource === "persisted");
+    hasRestoredPrefillSource && hasActivePrefilledLocationResolve;
   const queryForRequest = shouldUsePrefilledSuggestQuery
     ? toPrefilledLocationSuggestQuery(debouncedQueryValue)
     : debouncedQueryValue;
@@ -242,7 +252,7 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     suggestQuery.data?.visibleSuggestions ?? EMPTY_SUGGESTIONS;
 
   useEffect(() => {
-    if (!shouldAutoResolvePrefilledLocation) {
+    if (!isPrefilledLocationResolvePending) {
       return;
     }
 
@@ -254,10 +264,10 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
       return;
     }
 
-    consumeAutoResolvePrefilledLocation();
+    startPrefilledLocationResolve();
 
     if (dedupedSuggestions.length === 0) {
-      setHasPrefilledLocationNotMatched(false);
+      markPrefilledLocationNotFound();
       return;
     }
 
@@ -268,31 +278,34 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     });
 
     if (!selectedSuggestion) {
-      setHasPrefilledLocationNotMatched(true);
+      markPrefilledLocationNotMatched();
       return;
     }
 
-    setHasPrefilledLocationNotMatched(false);
     void retrieveAndSelectLocation({
       selectedSuggestion,
       hasMapboxToken,
       mapboxAccessToken,
       selectLocation,
       setHasRetrieveError,
+    }).finally(() => {
+      finishPrefilledLocationResolve();
     });
   }, [
-    consumeAutoResolvePrefilledLocation,
+    finishPrefilledLocationResolve,
     hasDebounced,
     hasMapboxToken,
+    isPrefilledLocationResolvePending,
     locationPrefillSource,
+    markPrefilledLocationNotFound,
+    markPrefilledLocationNotMatched,
     mapboxAccessToken,
     query,
     queryForRequest,
     dedupedSuggestions,
-    setHasPrefilledLocationNotMatched,
     selectLocation,
     selectedLocation,
-    shouldAutoResolvePrefilledLocation,
+    startPrefilledLocationResolve,
     suggestQuery.isSuccess,
   ]);
 
@@ -319,16 +332,10 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     if (hasRetrieveError) {
       setHasRetrieveError(false);
     }
-    if (hasPrefilledNotMatched) {
-      setHasPrefilledLocationNotMatched(false);
-    }
     setLocationSearchInput(value);
   };
 
   const onLocationOptionSubmit = (suggestionId: string) => {
-    if (hasPrefilledNotMatched) {
-      setHasPrefilledLocationNotMatched(false);
-    }
     const selectedSuggestion = findSubmittedSuggestion(
       dedupedSuggestions,
       suggestionId,
@@ -338,12 +345,22 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
       return;
     }
 
+    const shouldFinishPrefilledResolve = hasActivePrefilledLocationResolve;
+
+    if (shouldFinishPrefilledResolve) {
+      startPrefilledLocationResolve();
+    }
+
     void retrieveAndSelectLocation({
       selectedSuggestion,
       hasMapboxToken,
       mapboxAccessToken,
       selectLocation,
       setHasRetrieveError,
+    }).finally(() => {
+      if (shouldFinishPrefilledResolve) {
+        finishPrefilledLocationResolve();
+      }
     });
   };
 

--- a/frontend/src/pages/home/homeBootstrap.test.ts
+++ b/frontend/src/pages/home/homeBootstrap.test.ts
@@ -27,7 +27,7 @@ describe("resolveHomeBootstrapState", () => {
       sport: SportType.Basketball,
       locationSearchInput: "Perth, Western Australia, Australia",
       locationPrefillSource: "url",
-      shouldAutoResolvePrefilledLocation: true,
+      prefilledLocationResolveState: "pending",
     });
   });
 
@@ -53,7 +53,7 @@ describe("resolveHomeBootstrapState", () => {
       sport: SportType.Running,
       locationSearchInput: "Dampier, Western Australia, Australia",
       locationPrefillSource: "persisted",
-      shouldAutoResolvePrefilledLocation: true,
+      prefilledLocationResolveState: "pending",
     });
   });
 
@@ -75,7 +75,7 @@ describe("resolveHomeBootstrapState", () => {
       sport: DEFAULT_SPORT_TYPE,
       locationSearchInput: "Sydney, New South Wales, Australia",
       locationPrefillSource: "default",
-      shouldAutoResolvePrefilledLocation: true,
+      prefilledLocationResolveState: "pending",
     });
   });
 
@@ -100,7 +100,29 @@ describe("resolveHomeBootstrapState", () => {
       sport: SportType.Running,
       locationSearchInput: "Perth, Western Australia, Australia",
       locationPrefillSource: "persisted",
-      shouldAutoResolvePrefilledLocation: true,
+      prefilledLocationResolveState: "pending",
+    });
+  });
+
+  it("leaves prefilled location resolve idle when no location is available", () => {
+    expect(
+      resolveHomeBootstrapState({
+        hasUrlState: false,
+        defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
+        defaultSport: DEFAULT_SPORT_TYPE,
+        defaultLocationLabel: "   ",
+        urlProfile: null,
+        urlSport: null,
+        urlLocation: null,
+        persistedFilters: null,
+      }),
+    ).toEqual({
+      channel: "direct",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: "",
+      locationPrefillSource: "none",
+      prefilledLocationResolveState: "idle",
     });
   });
 });

--- a/frontend/src/pages/home/homeBootstrap.ts
+++ b/frontend/src/pages/home/homeBootstrap.ts
@@ -5,6 +5,7 @@ import type {
   HomeChannel,
   HomeStoreBootstrapPayload,
   LocationPrefillSource,
+  PrefilledLocationResolveState,
 } from "@/store/homeStore";
 
 interface ResolveHomeBootstrapStateParams {
@@ -79,7 +80,8 @@ export function resolveHomeBootstrapState({
     }
   }
 
-  const shouldAutoResolvePrefilledLocation = locationSearchInput.length > 0;
+  const prefilledLocationResolveState: PrefilledLocationResolveState =
+    locationSearchInput.length > 0 ? "pending" : "idle";
 
   return {
     channel,
@@ -87,6 +89,6 @@ export function resolveHomeBootstrapState({
     sport,
     locationSearchInput,
     locationPrefillSource,
-    shouldAutoResolvePrefilledLocation,
+    prefilledLocationResolveState,
   };
 }

--- a/frontend/src/store/homeStore.test.ts
+++ b/frontend/src/store/homeStore.test.ts
@@ -41,8 +41,7 @@ function resetHomeStore() {
     locationSearchInput: "",
     locationPrefillSource: "none",
     selectedLocation: null,
-    shouldAutoResolvePrefilledLocation: false,
-    hasPrefilledLocationNotMatched: false,
+    prefilledLocationResolveState: "idle",
     locationSessionToken: INITIAL_SESSION_TOKEN,
   });
 }
@@ -58,12 +57,14 @@ describe("homeStore location search", () => {
 
   it("clears the committed selection and preserves the draft when editing a location", () => {
     useHomeStore.getState().selectLocation(DAMPER_LOCATION);
+    useHomeStore.getState().markPrefilledLocationNotMatched();
 
     useHomeStore.getState().setLocationSearchInput("P");
 
     expect(useHomeStore.getState()).toMatchObject({
       locationSearchInput: "P",
       selectedLocation: null,
+      prefilledLocationResolveState: "idle",
     });
   });
 
@@ -98,13 +99,48 @@ describe("homeStore location search", () => {
   it("restores a committed selection and formatted label after choosing a new suggestion", () => {
     useHomeStore.getState().selectLocation(DAMPER_LOCATION);
     useHomeStore.getState().setLocationSearchInput("Per");
+    useHomeStore.getState().startPrefilledLocationResolve();
 
     useHomeStore.getState().selectLocation(PERTH_LOCATION);
 
     expect(useHomeStore.getState()).toMatchObject({
       locationSearchInput: PERTH_LOCATION.displayLabel,
       selectedLocation: PERTH_LOCATION,
+      prefilledLocationResolveState: "idle",
     });
+  });
+
+  it("tracks prefilled location resolve state transitions", () => {
+    useHomeStore.getState().bootstrap({
+      channel: "shared",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: "Singapore, Singapore",
+      locationPrefillSource: "url",
+      prefilledLocationResolveState: "pending",
+    });
+
+    expect(useHomeStore.getState().prefilledLocationResolveState).toBe(
+      "pending",
+    );
+
+    useHomeStore.getState().startPrefilledLocationResolve();
+    expect(useHomeStore.getState().prefilledLocationResolveState).toBe(
+      "resolving",
+    );
+
+    useHomeStore.getState().markPrefilledLocationNotFound();
+    expect(useHomeStore.getState().prefilledLocationResolveState).toBe(
+      "not_found",
+    );
+
+    useHomeStore.getState().markPrefilledLocationNotMatched();
+    expect(useHomeStore.getState().prefilledLocationResolveState).toBe(
+      "not_matched",
+    );
+
+    useHomeStore.getState().finishPrefilledLocationResolve();
+    expect(useHomeStore.getState().prefilledLocationResolveState).toBe("idle");
   });
 
   it("keeps the current sport and location selection when the profile changes", () => {

--- a/frontend/src/store/homeStore.ts
+++ b/frontend/src/store/homeStore.ts
@@ -8,6 +8,12 @@ import { DEFAULT_SPORT_TYPE, type SportType } from "@/domain/sport";
 
 export type HomeChannel = "shared" | "direct";
 export type LocationPrefillSource = "url" | "persisted" | "default" | "none";
+export type PrefilledLocationResolveState =
+  | "idle"
+  | "pending"
+  | "resolving"
+  | "not_found"
+  | "not_matched";
 
 export interface HomeStoreBootstrapPayload {
   channel: HomeChannel;
@@ -15,7 +21,7 @@ export interface HomeStoreBootstrapPayload {
   sport: SportType;
   locationSearchInput: string;
   locationPrefillSource: LocationPrefillSource;
-  shouldAutoResolvePrefilledLocation: boolean;
+  prefilledLocationResolveState: PrefilledLocationResolveState;
 }
 
 interface HomeStoreState {
@@ -26,8 +32,7 @@ interface HomeStoreState {
   locationSearchInput: string;
   locationPrefillSource: LocationPrefillSource;
   selectedLocation: LocationSuggestion | null;
-  shouldAutoResolvePrefilledLocation: boolean;
-  hasPrefilledLocationNotMatched: boolean;
+  prefilledLocationResolveState: PrefilledLocationResolveState;
   locationSessionToken: string;
 
   bootstrap: (payload: HomeStoreBootstrapPayload) => void;
@@ -35,8 +40,10 @@ interface HomeStoreState {
   setSport: (sport: SportType) => void;
   setLocationSearchInput: (value: string) => void;
   selectLocation: (suggestion: LocationSuggestion) => void;
-  consumeAutoResolvePrefilledLocation: () => void;
-  setHasPrefilledLocationNotMatched: (value: boolean) => void;
+  startPrefilledLocationResolve: () => void;
+  finishPrefilledLocationResolve: () => void;
+  markPrefilledLocationNotFound: () => void;
+  markPrefilledLocationNotMatched: () => void;
 }
 
 function createSessionToken(): string {
@@ -61,8 +68,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
   locationSearchInput: "",
   locationPrefillSource: "none",
   selectedLocation: null,
-  shouldAutoResolvePrefilledLocation: false,
-  hasPrefilledLocationNotMatched: false,
+  prefilledLocationResolveState: "idle",
   locationSessionToken: createSessionToken(),
 
   bootstrap: ({
@@ -71,7 +77,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
     sport,
     locationSearchInput,
     locationPrefillSource,
-    shouldAutoResolvePrefilledLocation,
+    prefilledLocationResolveState,
   }) =>
     set({
       isBootstrapped: true,
@@ -81,8 +87,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
       locationSearchInput,
       locationPrefillSource,
       selectedLocation: null,
-      shouldAutoResolvePrefilledLocation,
-      hasPrefilledLocationNotMatched: false,
+      prefilledLocationResolveState,
       locationSessionToken: createSessionToken(),
     }),
   setProfile: (profile) => set({ profile }),
@@ -101,8 +106,7 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
         locationSearchInput: value,
         locationPrefillSource: "none",
         ...(shouldClearSelectedLocation ? { selectedLocation: null } : {}),
-        shouldAutoResolvePrefilledLocation: false,
-        hasPrefilledLocationNotMatched: false,
+        prefilledLocationResolveState: "idle",
         ...(isStartingNewSearch
           ? { locationSessionToken: createSessionToken() }
           : {}),
@@ -113,11 +117,14 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
       selectedLocation: suggestion,
       locationSearchInput: suggestion.displayLabel,
       locationPrefillSource: "none",
-      shouldAutoResolvePrefilledLocation: false,
-      hasPrefilledLocationNotMatched: false,
+      prefilledLocationResolveState: "idle",
     }),
-  consumeAutoResolvePrefilledLocation: () =>
-    set({ shouldAutoResolvePrefilledLocation: false }),
-  setHasPrefilledLocationNotMatched: (value) =>
-    set({ hasPrefilledLocationNotMatched: value }),
+  startPrefilledLocationResolve: () =>
+    set({ prefilledLocationResolveState: "resolving" }),
+  finishPrefilledLocationResolve: () =>
+    set({ prefilledLocationResolveState: "idle" }),
+  markPrefilledLocationNotFound: () =>
+    set({ prefilledLocationResolveState: "not_found" }),
+  markPrefilledLocationNotMatched: () =>
+    set({ prefilledLocationResolveState: "not_matched" }),
 }));


### PR DESCRIPTION
## Summary
- Add bounded retry/backoff handling for transient Open-Meteo failures, including request errors, 408/429 responses, and 5xx responses.
- Preserve owned/injected HTTP client lifecycle behavior while routing forecast fetches through the retry path.
- Log weather-provider failures with redacted request URLs to avoid exposing precise coordinates.
- Refine Mapbox location suggestions to supported weather-location types, canonical `Name, Region, Country` labels, dedupe, and filtering of overly broad results.
- Improve restored URL/persisted location prefill handling, including city-state labels such as `Singapore, Singapore`, normalized re-querying, and manual dropdown fallback for non-canonical labels.
- Update frontend documentation for the revised location-search flow.

## Tests
- Add backend tests for Open-Meteo retry success, retry exhaustion, non-retryable statuses, validation behavior, and owned-client lifecycle.
- Expand frontend tests for Mapbox suggestion mapping, country fallback behavior, administrative-result filtering, dedupe, prefilled-location matching, dropdown fallback, and bootstrap/store state transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable weather fetching with bounded automatic retries and safer failure logging (no sensitive request details).
* **New Features**
  * Smarter location suggestion and prefill handling, including auto-open behavior for the location dropdown.
* **Bug Fixes**
  * Better filtering of Mapbox suggestions and fixes for repeated/non-canonical prefilled labels.
* **Documentation**
  * Clarified Mapbox location-search flow in the README.
* **Tests**
  * Expanded tests for retry behavior and location-suggestion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->