### PR TITLE
Improve frontend API resilience and failure toasts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -222,7 +222,8 @@ Example response:
   forecast point; in that case the error payload uses the earliest candidate row and includes:
   - `unknown_inputs`
   - `available_inputs`
-- Upstream weather failures return `502`.
+- Upstream weather failures return `502` with:
+  `{"detail": "Weather provider unavailable", "error_code": "weather_provider_unavailable"}`.
 - Future forecast rows with missing inputs are skipped instead of failing the request.
 
 ## Notes

--- a/backend/src/sma_extreme_heat_backend/core/errors.py
+++ b/backend/src/sma_extreme_heat_backend/core/errors.py
@@ -6,21 +6,27 @@ from typing import Any
 class AppError(Exception):
     """Base application error with an HTTP status code and response-safe detail."""
 
-    def __init__(self, status_code: int, detail: Any) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        detail: Any,
+        error_code: str | None = None,
+    ) -> None:
         """Store the status code and serializable detail returned by the API layer."""
 
         super().__init__(str(detail))
         self.status_code = status_code
         self.detail = detail
+        self.error_code = error_code
 
 
 class UpstreamServiceError(AppError):
     """Base error for failed upstream dependencies."""
 
-    def __init__(self, detail: str) -> None:
+    def __init__(self, detail: str, error_code: str | None = None) -> None:
         """Normalize upstream failures into the shared 502 application error shape."""
 
-        super().__init__(status_code=502, detail=detail)
+        super().__init__(status_code=502, detail=detail, error_code=error_code)
 
 
 class WeatherProviderError(UpstreamServiceError):
@@ -29,7 +35,10 @@ class WeatherProviderError(UpstreamServiceError):
     def __init__(self, detail: str = "Weather provider unavailable") -> None:
         """Build the stable weather-provider error exposed to API callers."""
 
-        super().__init__(detail=detail)
+        super().__init__(
+            detail=detail,
+            error_code="weather_provider_unavailable",
+        )
 
 
 class RiskCalculationError(AppError):

--- a/backend/src/sma_extreme_heat_backend/main.py
+++ b/backend/src/sma_extreme_heat_backend/main.py
@@ -40,7 +40,11 @@ def create_app() -> FastAPI:
     async def app_error_handler(_: Request, exc: AppError) -> JSONResponse:
         """Map typed application errors into stable JSON responses."""
 
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+        content = {"detail": exc.detail}
+        if exc.error_code is not None:
+            content["error_code"] = exc.error_code
+
+        return JSONResponse(status_code=exc.status_code, content=content)
 
     app.include_router(router)
 

--- a/backend/tests/api/test_home_risk.py
+++ b/backend/tests/api/test_home_risk.py
@@ -334,7 +334,10 @@ def test_post_home_risk_weather_upstream_error_returns_502() -> None:
         )
 
     assert response.status_code == 502
-    assert response.json() == {"detail": "Weather provider unavailable"}
+    assert response.json() == {
+        "detail": "Weather provider unavailable",
+        "error_code": "weather_provider_unavailable",
+    }
 
 
 def test_post_home_risk_missing_wind_returns_422_unknown_inputs() -> None:

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -83,15 +83,18 @@
 - `VITE_MAPBOX_ACCESS_TOKEN` is required for location suggest/retrieve.
 - Frontend must resolve coordinates via retrieve before risk requests.
 - Valid prefilled `loc` from URL or local persistence should auto-trigger suggest/retrieve and then risk fetch.
-- Backend risk payload must be `sport + latitude + longitude` only.
+- Backend risk payload must be `sport + latitude + longitude + profile` only.
 - Risk must refetch when selected location coordinates resolve and when sport changes.
 - Missing token must show a configuration error (no silent fallback).
 - Suggest failures must show a retryable error (no local fallback path).
 - Retrieve failures must show a retryable error and must block risk fetch.
 - Risk API failures must be surfaced and keep the last valid result.
-- On successful fetch, update `sport` and `loc` query params with replace history.
+- On successful fetch, update `profile`, `sport`, and `loc` query params with replace history.
 - Persist to localStorage only for direct visits (not shared links).
 - Forecast time display uses backend-provided `time_local` for point labels/grouping and `request.location.timezone` for date formatting.
+- Profile support is reserved for a future release: keep profile in the API,
+  URL, and localStorage contracts, but do not expose a Profile select in Home
+  filters and keep bootstrap fixed to `ADULT`.
 
 ## Testing Expectations
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -92,7 +92,9 @@ Import rules:
 - Risk is fetched automatically when:
   - a location suggestion is selected (manual or auto-resolved) and coordinates are resolved, and
   - the sport changes.
-- Risk API failures are tracked internally and keep the last valid result (no silent fallback to fixtures), but API error messages are not currently shown in UI.
+- Location and risk calculation failures are shown as bottom error toasts.
+- Risk API failures keep the last valid result and do not silently fall back to fixtures.
+- Backend `weather_provider_unavailable` errors are mapped to a weather-provider-specific toast.
 - After a successful fetch:
   - URL query params update (`profile`, `sport`, `loc`) and
   - the last selection is persisted to localStorage only for direct visits (not shared links).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -91,17 +91,16 @@ Import rules:
 - Risk API response returns a non-empty `forecast[]` plus a nested `request` block containing `sport`, `profile`, and `location`; backend defines `forecast[0]` as the earliest complete forecast point, each forecast row includes both `time_utc` and `time_local`, and frontend derives the current risk from `forecast[0]` while grouping chart days from `time_local`.
 - Risk is fetched automatically when:
   - a location suggestion is selected (manual or auto-resolved) and coordinates are resolved, and
-  - the sport changes, and
-  - the selected profile changes.
-- Risk API failures are shown in UI and keep the last valid result (no silent fallback to fixtures).
+  - the sport changes.
+- Risk API failures are tracked internally and keep the last valid result (no silent fallback to fixtures), but API error messages are not currently shown in UI.
 - After a successful fetch:
   - URL query params update (`profile`, `sport`, `loc`) and
   - the last selection is persisted to localStorage only for direct visits (not shared links).
 - Dates are formatted in the selected location timezone supplied by the backend.
 - API time contract: forecast responses must carry `time_utc` as ISO-8601 UTC (`...Z`) and `time_local` as ISO-8601 local time with an explicit offset.
-- The Home filters expose a Profile select above Location and Sport.
-- Public profile values are `ADULT`, `UNDER_10`, `AGE_10_13`, and `AGE_14_17`.
-- The current profile is sent to the backend and restored from shared URLs or local persistence.
+- Profile support is reserved for a future release. The frontend keeps the profile domain/store/API contract, but the Home filters do not currently expose a Profile select and bootstrap keeps the active profile fixed to `ADULT`.
+- Public reserved profile values are `ADULT`, `UNDER_10`, `AGE_10_13`, and `AGE_14_17`.
+- The current frozen profile is sent to the backend and written to URLs/local persistence for contract compatibility; restored URL/local profile values are ignored until profile selection is re-enabled.
 
 ## i18n
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,7 +53,17 @@ const router = createBrowserRouter(
   },
 );
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
 
 function AppContent() {
   const { t } = useTranslation();

--- a/frontend/src/api/apiErrors.ts
+++ b/frontend/src/api/apiErrors.ts
@@ -9,6 +9,7 @@ export interface ApiErrorParams {
   kind: ApiErrorKind;
   message: string;
   status?: number;
+  serverCode?: string;
   cause?: unknown;
 }
 
@@ -18,13 +19,15 @@ export interface ApiErrorParams {
 export class ApiError extends Error {
   readonly kind: ApiErrorKind;
   readonly status?: number;
+  readonly serverCode?: string;
   override readonly cause?: unknown;
 
-  constructor({ kind, message, status, cause }: ApiErrorParams) {
+  constructor({ kind, message, status, serverCode, cause }: ApiErrorParams) {
     super(message);
     this.name = "ApiError";
     this.kind = kind;
     this.status = status;
+    this.serverCode = serverCode;
     this.cause = cause;
   }
 }

--- a/frontend/src/api/apiErrors.ts
+++ b/frontend/src/api/apiErrors.ts
@@ -1,0 +1,71 @@
+export type ApiErrorKind =
+  | "missing_config"
+  | "abort"
+  | "http_status"
+  | "invalid_response"
+  | "network";
+
+export interface ApiErrorParams {
+  kind: ApiErrorKind;
+  message: string;
+  status?: number;
+  cause?: unknown;
+}
+
+/**
+ * Structured error used by frontend API adapters for control flow.
+ */
+export class ApiError extends Error {
+  readonly kind: ApiErrorKind;
+  readonly status?: number;
+  override readonly cause?: unknown;
+
+  constructor({ kind, message, status, cause }: ApiErrorParams) {
+    super(message);
+    this.name = "ApiError";
+    this.kind = kind;
+    this.status = status;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Returns whether an unknown value is a structured frontend API error.
+ */
+export function isApiError(value: unknown): value is ApiError {
+  return value instanceof ApiError;
+}
+
+/**
+ * Returns whether an unknown value is a structured aborted API request.
+ */
+export function isAbortApiError(value: unknown): boolean {
+  return isApiError(value) && value.kind === "abort";
+}
+
+/**
+ * Detects native fetch abort errors without relying on DOMException instances.
+ */
+export function isAbortError(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    value.name === "AbortError"
+  );
+}
+
+/**
+ * Normalizes thrown fetch values into a structured API error.
+ */
+export function toApiError(error: unknown, message: string): ApiError {
+  if (isApiError(error)) {
+    return error;
+  }
+
+  return new ApiError({
+    kind: isAbortError(error) ? "abort" : "network",
+    message,
+    cause: error,
+  });
+}

--- a/frontend/src/api/apiRetryPolicy.test.ts
+++ b/frontend/src/api/apiRetryPolicy.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/api/apiErrors";
+import {
+  getRetryDelayMs,
+  retryApiRequest,
+  shouldRetryHeatRiskError,
+  shouldRetryMapboxRetrieveError,
+} from "@/api/apiRetryPolicy";
+import { MapboxApiError } from "@/api/mapboxErrors";
+
+function mapboxRetrieveError(params: {
+  kind: "abort" | "http_status" | "invalid_response" | "network";
+  status?: number;
+}): MapboxApiError {
+  return new MapboxApiError({
+    endpoint: "retrieve",
+    message: params.kind,
+    ...params,
+  });
+}
+
+function heatRiskError(params: {
+  kind:
+    | "abort"
+    | "http_status"
+    | "invalid_response"
+    | "missing_config"
+    | "network";
+  status?: number;
+}): ApiError {
+  return new ApiError({
+    message: params.kind,
+    ...params,
+  });
+}
+
+describe("api retry policy", () => {
+  it("uses short fixed retry delays for each bounded retry scope", () => {
+    expect(getRetryDelayMs({ scope: "mapbox_retrieve" })).toBe(400);
+    expect(getRetryDelayMs({ scope: "heat_risk" })).toBe(500);
+  });
+
+  it("retries only transient Mapbox retrieve failures", () => {
+    expect(
+      shouldRetryMapboxRetrieveError(mapboxRetrieveError({ kind: "network" })),
+    ).toBe(true);
+    expect(
+      shouldRetryMapboxRetrieveError(
+        mapboxRetrieveError({ kind: "http_status", status: 429 }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryMapboxRetrieveError(
+        mapboxRetrieveError({ kind: "http_status", status: 500 }),
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldRetryMapboxRetrieveError(mapboxRetrieveError({ kind: "abort" })),
+    ).toBe(false);
+    expect(
+      shouldRetryMapboxRetrieveError(
+        mapboxRetrieveError({ kind: "invalid_response" }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryMapboxRetrieveError(
+        mapboxRetrieveError({ kind: "http_status", status: 404 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("retries only transient backend heat-risk failures", () => {
+    expect(shouldRetryHeatRiskError(heatRiskError({ kind: "network" }))).toBe(
+      true,
+    );
+    expect(
+      shouldRetryHeatRiskError(
+        heatRiskError({ kind: "http_status", status: 502 }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryHeatRiskError(
+        heatRiskError({ kind: "http_status", status: 503 }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryHeatRiskError(
+        heatRiskError({ kind: "http_status", status: 504 }),
+      ),
+    ).toBe(true);
+
+    expect(shouldRetryHeatRiskError(heatRiskError({ kind: "abort" }))).toBe(
+      false,
+    );
+    expect(
+      shouldRetryHeatRiskError(heatRiskError({ kind: "invalid_response" })),
+    ).toBe(false);
+    expect(
+      shouldRetryHeatRiskError(heatRiskError({ kind: "missing_config" })),
+    ).toBe(false);
+    expect(
+      shouldRetryHeatRiskError(
+        heatRiskError({ kind: "http_status", status: 429 }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryHeatRiskError(
+        heatRiskError({ kind: "http_status", status: 422 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("retries an operation once when the policy allows it", async () => {
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new ApiError({ kind: "network", message: "bad" }))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      retryApiRequest(operation, {
+        maxRetries: 1,
+        delayMs: 0,
+        shouldRetry: shouldRetryHeatRiskError,
+      }),
+    ).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when the continuation guard turns false", async () => {
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new ApiError({ kind: "network", message: "bad" }));
+    const canContinue = vi.fn(() => false);
+
+    await expect(
+      retryApiRequest(
+        operation,
+        {
+          maxRetries: 1,
+          delayMs: 0,
+          shouldRetry: shouldRetryHeatRiskError,
+        },
+        { canContinue },
+      ),
+    ).rejects.toMatchObject({ kind: "network" });
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api/apiRetryPolicy.ts
+++ b/frontend/src/api/apiRetryPolicy.ts
@@ -1,0 +1,119 @@
+import { ApiError, isApiError } from "@/api/apiErrors";
+import { MapboxApiError } from "@/api/mapboxErrors";
+
+const MAPBOX_RETRIEVE_RETRY_DELAY_MS = 400;
+const HEAT_RISK_RETRY_DELAY_MS = 500;
+const SINGLE_RETRY = 1;
+
+export interface RetryDelayParams {
+  scope: "mapbox_retrieve" | "heat_risk";
+}
+
+export type RetryContinuationGuard = () => boolean;
+
+export interface ApiRetryPolicy {
+  maxRetries: number;
+  delayMs: number;
+  shouldRetry: (error: unknown) => boolean;
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, delayMs);
+  });
+}
+
+function isHttpStatus(error: unknown, statuses: readonly number[]): boolean {
+  return (
+    isApiError(error) &&
+    error.kind === "http_status" &&
+    error.status !== undefined &&
+    statuses.includes(error.status)
+  );
+}
+
+function isHttpStatusAtLeast(error: unknown, lowerBound: number): boolean {
+  return (
+    isApiError(error) &&
+    error.kind === "http_status" &&
+    error.status !== undefined &&
+    error.status >= lowerBound
+  );
+}
+
+/**
+ * Returns the short fixed retry delay for a bounded frontend API retry.
+ */
+export function getRetryDelayMs({ scope }: RetryDelayParams): number {
+  return scope === "mapbox_retrieve"
+    ? MAPBOX_RETRIEVE_RETRY_DELAY_MS
+    : HEAT_RISK_RETRY_DELAY_MS;
+}
+
+/**
+ * Returns whether a Mapbox retrieve error is likely transient.
+ */
+export function shouldRetryMapboxRetrieveError(error: unknown): boolean {
+  return (
+    error instanceof MapboxApiError &&
+    error.endpoint === "retrieve" &&
+    (error.kind === "network" ||
+      isHttpStatus(error, [429]) ||
+      isHttpStatusAtLeast(error, 500))
+  );
+}
+
+/**
+ * Returns whether a backend heat-risk error is likely transient.
+ */
+export function shouldRetryHeatRiskError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    (error.kind === "network" || isHttpStatus(error, [502, 503, 504]))
+  );
+}
+
+/**
+ * Runs an API operation with a bounded retry policy and optional freshness guard.
+ */
+export async function retryApiRequest<T>(
+  operation: () => Promise<T>,
+  policy: ApiRetryPolicy,
+  options?: { canContinue?: RetryContinuationGuard },
+): Promise<T> {
+  let retryCount = 0;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      const canContinue = options?.canContinue?.() ?? true;
+      if (
+        !canContinue ||
+        retryCount >= policy.maxRetries ||
+        !policy.shouldRetry(error)
+      ) {
+        throw error;
+      }
+
+      retryCount += 1;
+      await sleep(policy.delayMs);
+
+      if (options?.canContinue && !options.canContinue()) {
+        throw error;
+      }
+    }
+  }
+}
+
+export const mapboxRetrieveRetryPolicy: ApiRetryPolicy = {
+  maxRetries: SINGLE_RETRY,
+  delayMs: getRetryDelayMs({ scope: "mapbox_retrieve" }),
+  shouldRetry: shouldRetryMapboxRetrieveError,
+};
+
+export const heatRiskRetryPolicy: ApiRetryPolicy = {
+  maxRetries: SINGLE_RETRY,
+  delayMs: getRetryDelayMs({ scope: "heat_risk" }),
+  shouldRetry: shouldRetryHeatRiskError,
+};

--- a/frontend/src/api/heatRisk.test.ts
+++ b/frontend/src/api/heatRisk.test.ts
@@ -108,6 +108,31 @@ describe("fetchHeatRisk", () => {
     });
   });
 
+  it("classifies weather provider backend error codes", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: "Weather provider unavailable",
+          error_code: "weather_provider_unavailable",
+        }),
+        { status: 502 },
+      ),
+    );
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "weather_provider_unavailable",
+      status: 502,
+    });
+  });
+
   it("classifies invalid backend response shapes", async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ forecast: [] }), { status: 200 }),

--- a/frontend/src/api/heatRisk.test.ts
+++ b/frontend/src/api/heatRisk.test.ts
@@ -1,26 +1,162 @@
-import { describe, expect, it } from "vitest";
-import { buildHeatRiskRequest, isHeatRiskApiResponse } from "@/api/heatRisk";
-import { HEAT_RISK_PROFILE_VALUES } from "@/domain/heatRiskProfile";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchHeatRisk, isHeatRiskApiResponse } from "@/api/heatRisk";
 
-describe("buildHeatRiskRequest", () => {
-  it.each(HEAT_RISK_PROFILE_VALUES)(
-    "preserves the caller-provided %s profile in the Home risk payload",
-    (profile) => {
-      expect(
-        buildHeatRiskRequest({
+const VALID_HEAT_RISK_RESPONSE = {
+  request: {
+    sport: "SOCCER",
+    profile: "ADULT",
+    location: {
+      latitude: -33.847,
+      longitude: 151.067,
+      timezone: "Australia/Sydney",
+    },
+  },
+  forecast: [
+    {
+      time_utc: "2026-03-09T00:00:00Z",
+      time_local: "2026-03-09T11:00:00+11:00",
+      inputs: {
+        air_temperature_c: 31,
+        mean_radiant_temperature_c: 37.25,
+        relative_humidity_pct: 62,
+        wind_speed_10m_ms: 1.5,
+        direct_normal_irradiance_wm2: 700,
+      },
+      heat_risk: {
+        risk_level_interpolated: 1.94,
+        t_medium: 34.5,
+        t_high: 37.1,
+        t_extreme: 39.2,
+        recommendation: "Increase hydration & modify clothing",
+      },
+    },
+  ],
+};
+
+describe("fetchHeatRisk", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("sends the frozen ADULT profile in the Home risk payload", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(VALID_HEAT_RISK_RESPONSE), { status: 200 }),
+    );
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/home/risk",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
           sport: "SOCCER",
           latitude: -33.847,
           longitude: 151.067,
-          profile,
+          profile: "ADULT",
         }),
-      ).toEqual({
-        sport: "SOCCER",
-        latitude: -33.847,
-        longitude: 151.067,
-        profile,
-      });
-    },
-  );
+      }),
+    );
+  });
+
+  it("returns missing_config without calling fetch when the API base URL is absent", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "missing_config",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("classifies backend HTTP errors with the response status", async () => {
+    fetchMock.mockResolvedValue(new Response("bad gateway", { status: 502 }));
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "http_status",
+      status: 502,
+    });
+  });
+
+  it("classifies invalid backend response shapes", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ forecast: [] }), { status: 200 }),
+    );
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid_response",
+    });
+  });
+
+  it("classifies network failures", async () => {
+    fetchMock.mockRejectedValue(new Error("offline"));
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "network",
+    });
+  });
+
+  it("classifies aborted requests separately from network failures", async () => {
+    fetchMock.mockRejectedValue(new DOMException("Aborted", "AbortError"));
+
+    const result = await fetchHeatRisk({
+      sport: "SOCCER",
+      latitude: -33.847,
+      longitude: 151.067,
+      profile: "ADULT",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "abort",
+    });
+  });
 });
 
 describe("isHeatRiskApiResponse", () => {

--- a/frontend/src/api/heatRisk.ts
+++ b/frontend/src/api/heatRisk.ts
@@ -1,6 +1,7 @@
 import type { SportType } from "@/domain/sport";
+import { isApiError } from "@/api/apiErrors";
 import { endpoints } from "@/api/endpoints";
-import { httpClient } from "@/api/httpClient";
+import { httpClient, isApiBaseUrlConfigured } from "@/api/httpClient";
 import {
   isHeatRiskProfile,
   type HeatRiskProfile,
@@ -55,9 +56,11 @@ export interface HeatRiskApiResponse {
 }
 
 export type HeatRiskErrorReason =
-  | "missing_api_base_url"
+  | "missing_config"
+  | "abort"
+  | "http_status"
   | "invalid_response"
-  | "network_error";
+  | "network";
 
 export type HeatRiskApiResult =
   | {
@@ -67,19 +70,8 @@ export type HeatRiskApiResult =
   | {
       ok: false;
       reason: HeatRiskErrorReason;
+      status?: number;
     };
-
-/**
- * Builds the Home heat-risk request payload.
- */
-export function buildHeatRiskRequest(payload: {
-  sport: SportType;
-  latitude: number;
-  longitude: number;
-  profile: HeatRiskProfile;
-}): HeatRiskRequest {
-  return payload;
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -194,10 +186,10 @@ export async function fetchHeatRisk(
   payload: HeatRiskRequest,
   options?: { signal?: AbortSignal },
 ): Promise<HeatRiskApiResult> {
-  if (!import.meta.env.VITE_API_BASE_URL) {
+  if (!isApiBaseUrlConfigured()) {
     return {
       ok: false,
-      reason: "missing_api_base_url",
+      reason: "missing_config",
     };
   }
 
@@ -220,10 +212,18 @@ export async function fetchHeatRisk(
       ok: true,
       data: response,
     };
-  } catch {
+  } catch (error) {
+    if (isApiError(error)) {
+      return {
+        ok: false,
+        reason: error.kind,
+        ...(error.status !== undefined ? { status: error.status } : {}),
+      };
+    }
+
     return {
       ok: false,
-      reason: "network_error",
+      reason: "network",
     };
   }
 }

--- a/frontend/src/api/heatRisk.ts
+++ b/frontend/src/api/heatRisk.ts
@@ -60,7 +60,8 @@ export type HeatRiskErrorReason =
   | "abort"
   | "http_status"
   | "invalid_response"
-  | "network";
+  | "network"
+  | "weather_provider_unavailable";
 
 export type HeatRiskApiResult =
   | {
@@ -179,6 +180,16 @@ export function isHeatRiskApiResponse(
   );
 }
 
+function toHeatRiskErrorReason(error: unknown): HeatRiskErrorReason {
+  if (isApiError(error)) {
+    return error.serverCode === "weather_provider_unavailable"
+      ? "weather_provider_unavailable"
+      : error.kind;
+  }
+
+  return "network";
+}
+
 /**
  * Fetches and validates the raw backend heat-risk response payload.
  */
@@ -213,17 +224,12 @@ export async function fetchHeatRisk(
       data: response,
     };
   } catch (error) {
-    if (isApiError(error)) {
-      return {
-        ok: false,
-        reason: error.kind,
-        ...(error.status !== undefined ? { status: error.status } : {}),
-      };
-    }
-
     return {
       ok: false,
-      reason: "network",
+      reason: toHeatRiskErrorReason(error),
+      ...(isApiError(error) && error.status !== undefined
+        ? { status: error.status }
+        : {}),
     };
   }
 }

--- a/frontend/src/api/httpClient.test.ts
+++ b/frontend/src/api/httpClient.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/api/apiErrors";
+import { httpClient } from "@/api/httpClient";
+
+describe("httpClient", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("preserves backend error codes on non-OK JSON responses", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: "Weather provider unavailable",
+          error_code: "weather_provider_unavailable",
+        }),
+        { status: 502 },
+      ),
+    );
+
+    await expect(httpClient("/home/risk")).rejects.toMatchObject({
+      name: "ApiError",
+      kind: "http_status",
+      status: 502,
+      serverCode: "weather_provider_unavailable",
+    } satisfies Partial<ApiError>);
+  });
+});

--- a/frontend/src/api/httpClient.test.ts
+++ b/frontend/src/api/httpClient.test.ts
@@ -5,6 +5,14 @@ import { httpClient } from "@/api/httpClient";
 describe("httpClient", () => {
   const fetchMock = vi.fn<typeof fetch>();
 
+  const getRequestHeaders = () => {
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers;
+
+    expect(headers).toBeDefined();
+
+    return new Headers(headers);
+  };
+
   beforeEach(() => {
     vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
     vi.stubGlobal("fetch", fetchMock);
@@ -33,5 +41,51 @@ describe("httpClient", () => {
       status: 502,
       serverCode: "weather_provider_unavailable",
     } satisfies Partial<ApiError>);
+  });
+
+  it("preserves headers provided as a Headers instance", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    await httpClient("/home/risk", {
+      headers: new Headers([["X-Trace-Id", "trace-1"]]),
+    });
+
+    const headers = getRequestHeaders();
+
+    expect(headers.get("X-Trace-Id")).toBe("trace-1");
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("preserves headers provided as tuple arrays", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    await httpClient("/home/risk", {
+      headers: [["X-Session-Id", "session-1"]],
+    });
+
+    const headers = getRequestHeaders();
+
+    expect(headers.get("X-Session-Id")).toBe("session-1");
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("does not overwrite a caller-provided Content-Type header", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    await httpClient("/home/risk", {
+      headers: {
+        "Content-Type": "application/merge-patch+json",
+      },
+    });
+
+    expect(getRequestHeaders().get("Content-Type")).toBe(
+      "application/merge-patch+json",
+    );
   });
 });

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -54,6 +54,16 @@ async function parseJsonResponse(response: Response): Promise<unknown> {
   }
 }
 
+function buildJsonHeaders(headers?: HeadersInit): Headers {
+  const mergedHeaders = new Headers(headers);
+
+  if (!mergedHeaders.has("Content-Type")) {
+    mergedHeaders.set("Content-Type", "application/json");
+  }
+
+  return mergedHeaders;
+}
+
 /**
  * Sends a JSON HTTP request to the configured backend base URL.
  */
@@ -66,10 +76,7 @@ export async function httpClient<T>(
   try {
     response = await fetch(buildUrl(path), {
       ...init,
-      headers: {
-        "Content-Type": "application/json",
-        ...(init?.headers ?? {}),
-      },
+      headers: buildJsonHeaders(init?.headers),
     });
   } catch (error) {
     throw toApiError(error, "Backend request failed");

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -22,6 +22,26 @@ function buildUrl(path: string) {
   return `${getApiBaseUrl()}${path}`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function parseBackendErrorCode(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    const payload: unknown = await response.json();
+
+    if (isRecord(payload) && typeof payload.error_code === "string") {
+      return payload.error_code;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
 async function parseJsonResponse(response: Response): Promise<unknown> {
   try {
     return await response.json();
@@ -56,9 +76,12 @@ export async function httpClient<T>(
   }
 
   if (!response.ok) {
+    const serverCode = await parseBackendErrorCode(response);
+
     throw new ApiError({
       kind: "http_status",
       status: response.status,
+      serverCode,
       message: `Backend request failed with HTTP ${response.status}`,
     });
   }

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -1,14 +1,37 @@
-const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? "").replace(
-  /\/$/,
-  "",
-);
+import { ApiError, toApiError } from "@/api/apiErrors";
+
+/**
+ * Returns the configured backend API base URL without a trailing slash.
+ */
+export function getApiBaseUrl(): string {
+  return (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/$/, "");
+}
+
+/**
+ * Returns whether backend API requests can be sent.
+ */
+export function isApiBaseUrlConfigured(): boolean {
+  return getApiBaseUrl().length > 0;
+}
 
 function buildUrl(path: string) {
   if (!path.startsWith("/")) {
     throw new Error(`API path must start with '/': ${path}`);
   }
 
-  return `${API_BASE_URL}${path}`;
+  return `${getApiBaseUrl()}${path}`;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new ApiError({
+      kind: "invalid_response",
+      message: "Backend response was not valid JSON",
+      cause: error,
+    });
+  }
 }
 
 /**
@@ -18,17 +41,27 @@ export async function httpClient<T>(
   path: string,
   init?: RequestInit,
 ): Promise<T> {
-  const response = await fetch(buildUrl(path), {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(init?.headers ?? {}),
-    },
-  });
+  let response: Response;
 
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  try {
+    response = await fetch(buildUrl(path), {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+  } catch (error) {
+    throw toApiError(error, "Backend request failed");
   }
 
-  return (await response.json()) as T;
+  if (!response.ok) {
+    throw new ApiError({
+      kind: "http_status",
+      status: response.status,
+      message: `Backend request failed with HTTP ${response.status}`,
+    });
+  }
+
+  return (await parseJsonResponse(response)) as T;
 }

--- a/frontend/src/api/mapboxErrors.test.ts
+++ b/frontend/src/api/mapboxErrors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMapboxHttpStatusError,
+  createMapboxInvalidResponseError,
+  toMapboxApiError,
+} from "@/api/mapboxErrors";
+
+describe("Mapbox API errors", () => {
+  it("preserves endpoint and status for HTTP errors", () => {
+    expect(createMapboxHttpStatusError("suggest", 429)).toMatchObject({
+      endpoint: "suggest",
+      kind: "http_status",
+      status: 429,
+    });
+  });
+
+  it("preserves endpoint for invalid response errors", () => {
+    expect(
+      createMapboxInvalidResponseError("retrieve", "bad payload"),
+    ).toMatchObject({
+      endpoint: "retrieve",
+      kind: "invalid_response",
+    });
+  });
+
+  it("classifies aborts separately from network failures", () => {
+    expect(
+      toMapboxApiError("retrieve", new DOMException("Aborted", "AbortError")),
+    ).toMatchObject({
+      endpoint: "retrieve",
+      kind: "abort",
+    });
+  });
+
+  it("classifies unknown thrown values as network failures", () => {
+    expect(toMapboxApiError("suggest", new Error("offline"))).toMatchObject({
+      endpoint: "suggest",
+      kind: "network",
+    });
+  });
+});

--- a/frontend/src/api/mapboxErrors.test.ts
+++ b/frontend/src/api/mapboxErrors.test.ts
@@ -3,6 +3,7 @@ import {
   createMapboxHttpStatusError,
   createMapboxInvalidResponseError,
   toMapboxApiError,
+  toMapboxResponseJsonError,
 } from "@/api/mapboxErrors";
 
 describe("Mapbox API errors", () => {
@@ -34,6 +35,40 @@ describe("Mapbox API errors", () => {
 
   it("classifies unknown thrown values as network failures", () => {
     expect(toMapboxApiError("suggest", new Error("offline"))).toMatchObject({
+      endpoint: "suggest",
+      kind: "network",
+    });
+  });
+
+  it("classifies response JSON syntax errors as invalid responses", () => {
+    const syntaxError = new SyntaxError("bad json");
+
+    expect(
+      toMapboxResponseJsonError("suggest", syntaxError, "not valid JSON"),
+    ).toMatchObject({
+      endpoint: "suggest",
+      kind: "invalid_response",
+      cause: syntaxError,
+    });
+  });
+
+  it("preserves abort classification for response JSON failures", () => {
+    expect(
+      toMapboxResponseJsonError(
+        "retrieve",
+        new DOMException("Aborted", "AbortError"),
+        "not valid JSON",
+      ),
+    ).toMatchObject({
+      endpoint: "retrieve",
+      kind: "abort",
+    });
+  });
+
+  it("classifies non-syntax response JSON failures as network failures", () => {
+    expect(
+      toMapboxResponseJsonError("suggest", new Error("stream failed"), "read"),
+    ).toMatchObject({
       endpoint: "suggest",
       kind: "network",
     });

--- a/frontend/src/api/mapboxErrors.ts
+++ b/frontend/src/api/mapboxErrors.ts
@@ -42,12 +42,38 @@ export function createMapboxHttpStatusError(
 export function createMapboxInvalidResponseError(
   endpoint: MapboxEndpoint,
   message: string,
+  cause?: unknown,
 ): MapboxApiError {
   return new MapboxApiError({
     endpoint,
     kind: "invalid_response",
     message,
+    cause,
   });
+}
+
+function hasErrorName(value: unknown, name: string): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    value.name === name
+  );
+}
+
+/**
+ * Normalizes Mapbox response JSON parsing failures without masking aborts.
+ */
+export function toMapboxResponseJsonError(
+  endpoint: MapboxEndpoint,
+  error: unknown,
+  message: string,
+): MapboxApiError {
+  if (hasErrorName(error, "SyntaxError")) {
+    return createMapboxInvalidResponseError(endpoint, message, error);
+  }
+
+  return toMapboxApiError(endpoint, error);
 }
 
 /**

--- a/frontend/src/api/mapboxErrors.ts
+++ b/frontend/src/api/mapboxErrors.ts
@@ -1,0 +1,69 @@
+import { ApiError, toApiError, type ApiErrorKind } from "@/api/apiErrors";
+
+export type MapboxEndpoint = "suggest" | "retrieve";
+
+/**
+ * Structured Mapbox API error carrying the failed endpoint.
+ */
+export class MapboxApiError extends ApiError {
+  readonly endpoint: MapboxEndpoint;
+
+  constructor(params: {
+    endpoint: MapboxEndpoint;
+    kind: ApiErrorKind;
+    message: string;
+    status?: number;
+    cause?: unknown;
+  }) {
+    super(params);
+    this.name = "MapboxApiError";
+    this.endpoint = params.endpoint;
+  }
+}
+
+/**
+ * Builds a Mapbox API error for non-OK HTTP responses.
+ */
+export function createMapboxHttpStatusError(
+  endpoint: MapboxEndpoint,
+  status: number,
+): MapboxApiError {
+  return new MapboxApiError({
+    endpoint,
+    kind: "http_status",
+    status,
+    message: `Mapbox ${endpoint} failed with HTTP ${status}`,
+  });
+}
+
+/**
+ * Builds a Mapbox API error for malformed response payloads.
+ */
+export function createMapboxInvalidResponseError(
+  endpoint: MapboxEndpoint,
+  message: string,
+): MapboxApiError {
+  return new MapboxApiError({
+    endpoint,
+    kind: "invalid_response",
+    message,
+  });
+}
+
+/**
+ * Normalizes thrown Mapbox request values into structured Mapbox API errors.
+ */
+export function toMapboxApiError(
+  endpoint: MapboxEndpoint,
+  error: unknown,
+): MapboxApiError {
+  const apiError = toApiError(error, `Mapbox ${endpoint} request failed`);
+
+  return new MapboxApiError({
+    endpoint,
+    kind: apiError.kind,
+    message: apiError.message,
+    status: apiError.status,
+    cause: apiError.cause,
+  });
+}

--- a/frontend/src/api/mapboxRetrieve.test.ts
+++ b/frontend/src/api/mapboxRetrieve.test.ts
@@ -83,6 +83,21 @@ describe("retrieveLocationCoordinates", () => {
     });
   });
 
+  it("throws an invalid_response error when retrieve returns non-JSON content", async () => {
+    fetchMock.mockResolvedValue(new Response("not-json", { status: 200 }));
+
+    await expect(
+      retrieveLocationCoordinates({
+        mapboxId: "place-sydney",
+        accessToken: "token",
+        sessionToken: "session",
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "retrieve",
+      kind: "invalid_response",
+    });
+  });
+
   it("throws an abort error when retrieve is cancelled", async () => {
     fetchMock.mockRejectedValue(new DOMException("Aborted", "AbortError"));
 

--- a/frontend/src/api/mapboxRetrieve.test.ts
+++ b/frontend/src/api/mapboxRetrieve.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { retrieveLocationCoordinates } from "@/api/mapboxRetrieve";
+
+describe("retrieveLocationCoordinates", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("extracts latitude and longitude from the first Mapbox feature", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          features: [
+            {
+              geometry: {
+                coordinates: [151.067, -33.847],
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      retrieveLocationCoordinates({
+        mapboxId: "place-sydney",
+        accessToken: "token",
+        sessionToken: "session",
+      }),
+    ).resolves.toEqual({
+      latitude: -33.847,
+      longitude: 151.067,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://api.mapbox.com/search/searchbox/v1/retrieve/place-sydney?",
+      ),
+      expect.any(Object),
+    );
+  });
+
+  it("throws a http_status error when retrieve returns a non-OK response", async () => {
+    fetchMock.mockResolvedValue(new Response("not found", { status: 404 }));
+
+    await expect(
+      retrieveLocationCoordinates({
+        mapboxId: "missing",
+        accessToken: "token",
+        sessionToken: "session",
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "retrieve",
+      kind: "http_status",
+      status: 404,
+    });
+  });
+
+  it("throws an invalid_response error when retrieve omits coordinates", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ features: [{ geometry: {} }] }), {
+        status: 200,
+      }),
+    );
+
+    await expect(
+      retrieveLocationCoordinates({
+        mapboxId: "place-sydney",
+        accessToken: "token",
+        sessionToken: "session",
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "retrieve",
+      kind: "invalid_response",
+    });
+  });
+
+  it("throws an abort error when retrieve is cancelled", async () => {
+    fetchMock.mockRejectedValue(new DOMException("Aborted", "AbortError"));
+
+    await expect(
+      retrieveLocationCoordinates({
+        mapboxId: "place-sydney",
+        accessToken: "token",
+        sessionToken: "session",
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "retrieve",
+      kind: "abort",
+    });
+  });
+});

--- a/frontend/src/api/mapboxRetrieve.ts
+++ b/frontend/src/api/mapboxRetrieve.ts
@@ -2,6 +2,7 @@ import {
   createMapboxHttpStatusError,
   createMapboxInvalidResponseError,
   toMapboxApiError,
+  toMapboxResponseJsonError,
 } from "@/api/mapboxErrors";
 
 const MAPBOX_RETRIEVE_ENDPOINT =
@@ -116,9 +117,10 @@ export async function retrieveLocationCoordinates({
   let payload: unknown;
   try {
     payload = await response.json();
-  } catch {
-    throw createMapboxInvalidResponseError(
+  } catch (error) {
+    throw toMapboxResponseJsonError(
       "retrieve",
+      error,
       "Mapbox retrieve response was not valid JSON",
     );
   }

--- a/frontend/src/api/mapboxRetrieve.ts
+++ b/frontend/src/api/mapboxRetrieve.ts
@@ -1,12 +1,14 @@
+import {
+  createMapboxHttpStatusError,
+  createMapboxInvalidResponseError,
+  toMapboxApiError,
+} from "@/api/mapboxErrors";
+
 const MAPBOX_RETRIEVE_ENDPOINT =
   "https://api.mapbox.com/search/searchbox/v1/retrieve";
 
 interface UnknownRecord {
   [key: string]: unknown;
-}
-
-interface MapboxRetrieveResponse {
-  features?: unknown[];
 }
 
 export interface MapboxRetrieveParams {
@@ -30,30 +32,52 @@ function toFiniteNumberOrNull(value: unknown): number | null {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
-function toCoordinates(payload: MapboxRetrieveResponse): RetrievedCoordinates {
+function toCoordinates(payload: unknown): RetrievedCoordinates {
+  if (!isRecord(payload)) {
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve response shape was invalid",
+    );
+  }
+
   if (!Array.isArray(payload.features) || payload.features.length === 0) {
-    throw new Error("Mapbox retrieve response did not include features");
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve response did not include features",
+    );
   }
 
   const firstFeature = payload.features[0];
   if (!isRecord(firstFeature)) {
-    throw new Error("Mapbox retrieve response feature format was invalid");
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve response feature format was invalid",
+    );
   }
 
   const geometry = firstFeature.geometry;
   if (!isRecord(geometry)) {
-    throw new Error("Mapbox retrieve response geometry was missing");
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve response geometry was missing",
+    );
   }
 
   const coordinates = geometry.coordinates;
   if (!Array.isArray(coordinates) || coordinates.length < 2) {
-    throw new Error("Mapbox retrieve response coordinates were missing");
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve response coordinates were missing",
+    );
   }
 
   const longitude = toFiniteNumberOrNull(coordinates[0]);
   const latitude = toFiniteNumberOrNull(coordinates[1]);
   if (longitude === null || latitude === null) {
-    throw new Error("Mapbox retrieve coordinates were invalid");
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve coordinates were invalid",
+    );
   }
 
   return { latitude, longitude };
@@ -74,14 +98,30 @@ export async function retrieveLocationCoordinates({
     session_token: sessionToken,
   });
 
-  const response = await fetch(
-    `${MAPBOX_RETRIEVE_ENDPOINT}/${path}?${params.toString()}`,
-    { signal },
-  );
-  if (!response.ok) {
-    throw new Error(`Mapbox retrieve failed with HTTP ${response.status}`);
+  let response: Response;
+
+  try {
+    response = await fetch(
+      `${MAPBOX_RETRIEVE_ENDPOINT}/${path}?${params.toString()}`,
+      { signal },
+    );
+  } catch (error) {
+    throw toMapboxApiError("retrieve", error);
   }
 
-  const payload = (await response.json()) as MapboxRetrieveResponse;
+  if (!response.ok) {
+    throw createMapboxHttpStatusError("retrieve", response.status);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw createMapboxInvalidResponseError(
+      "retrieve",
+      "Mapbox retrieve response was not valid JSON",
+    );
+  }
+
   return toCoordinates(payload);
 }

--- a/frontend/src/api/mapboxSuggest.test.ts
+++ b/frontend/src/api/mapboxSuggest.test.ts
@@ -449,6 +449,22 @@ describe("suggestLocations", () => {
     });
   });
 
+  it("throws an invalid_response error when Mapbox suggest returns invalid JSON", async () => {
+    fetchMock.mockResolvedValue(new Response("{", { status: 200 }));
+
+    await expect(
+      suggestLocations({
+        query: "Darwin",
+        accessToken: "token",
+        sessionToken: "session",
+        types: SUPPORTED_LOCATION_TYPES,
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "suggest",
+      kind: "invalid_response",
+    });
+  });
+
   it("throws a network error when Mapbox suggest cannot be reached", async () => {
     fetchMock.mockRejectedValue(new Error("offline"));
 

--- a/frontend/src/api/mapboxSuggest.test.ts
+++ b/frontend/src/api/mapboxSuggest.test.ts
@@ -410,6 +410,32 @@ describe("suggestLocations", () => {
   it("throws when Mapbox suggest returns a non-OK response", async () => {
     fetchMock.mockResolvedValue(new Response("bad gateway", { status: 502 }));
 
+    try {
+      await suggestLocations({
+        query: "Darwin",
+        accessToken: "token",
+        sessionToken: "session",
+        types: SUPPORTED_LOCATION_TYPES,
+      });
+      throw new Error("Expected Mapbox suggest to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Mapbox suggest failed with HTTP 502",
+      );
+      expect(error).toMatchObject({
+        endpoint: "suggest",
+        kind: "http_status",
+        status: 502,
+      });
+    }
+  });
+
+  it("throws an invalid_response error when Mapbox suggest returns a malformed payload", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ suggestions: "bad" }), { status: 200 }),
+    );
+
     await expect(
       suggestLocations({
         query: "Darwin",
@@ -417,6 +443,41 @@ describe("suggestLocations", () => {
         sessionToken: "session",
         types: SUPPORTED_LOCATION_TYPES,
       }),
-    ).rejects.toThrow("Mapbox suggest failed with HTTP 502");
+    ).rejects.toMatchObject({
+      endpoint: "suggest",
+      kind: "invalid_response",
+    });
+  });
+
+  it("throws a network error when Mapbox suggest cannot be reached", async () => {
+    fetchMock.mockRejectedValue(new Error("offline"));
+
+    await expect(
+      suggestLocations({
+        query: "Darwin",
+        accessToken: "token",
+        sessionToken: "session",
+        types: SUPPORTED_LOCATION_TYPES,
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "suggest",
+      kind: "network",
+    });
+  });
+
+  it("throws an abort error when Mapbox suggest is cancelled", async () => {
+    fetchMock.mockRejectedValue(new DOMException("Aborted", "AbortError"));
+
+    await expect(
+      suggestLocations({
+        query: "Darwin",
+        accessToken: "token",
+        sessionToken: "session",
+        types: SUPPORTED_LOCATION_TYPES,
+      }),
+    ).rejects.toMatchObject({
+      endpoint: "suggest",
+      kind: "abort",
+    });
   });
 });

--- a/frontend/src/api/mapboxSuggest.ts
+++ b/frontend/src/api/mapboxSuggest.ts
@@ -3,6 +3,7 @@ import {
   createMapboxHttpStatusError,
   createMapboxInvalidResponseError,
   toMapboxApiError,
+  toMapboxResponseJsonError,
 } from "@/api/mapboxErrors";
 import { LOCATION_SUGGEST_TYPES } from "@/domain/locationSearch";
 
@@ -235,9 +236,10 @@ export async function suggestLocations({
   let data: unknown;
   try {
     data = await response.json();
-  } catch {
-    throw createMapboxInvalidResponseError(
+  } catch (error) {
+    throw toMapboxResponseJsonError(
       "suggest",
+      error,
       "Mapbox suggest response was not valid JSON",
     );
   }

--- a/frontend/src/api/mapboxSuggest.ts
+++ b/frontend/src/api/mapboxSuggest.ts
@@ -1,4 +1,9 @@
 import type { LocationSuggestion } from "@/domain/location";
+import {
+  createMapboxHttpStatusError,
+  createMapboxInvalidResponseError,
+  toMapboxApiError,
+} from "@/api/mapboxErrors";
 import { LOCATION_SUGGEST_TYPES } from "@/domain/locationSearch";
 
 const MAPBOX_SUGGEST_ENDPOINT =
@@ -35,6 +40,15 @@ export interface MapboxSuggestParams {
 
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === "object" && value !== null;
+}
+
+function isMapboxSuggestResponse(
+  value: unknown,
+): value is MapboxSuggestResponse {
+  return (
+    isRecord(value) &&
+    (value.suggestions === undefined || Array.isArray(value.suggestions))
+  );
 }
 
 function toTrimmedString(value: unknown): string {
@@ -204,15 +218,37 @@ export async function suggestLocations({
     language,
   });
 
-  const response = await fetch(`${MAPBOX_SUGGEST_ENDPOINT}?${queryString}`, {
-    signal,
-  });
+  let response: Response;
 
-  if (!response.ok) {
-    throw new Error(`Mapbox suggest failed with HTTP ${response.status}`);
+  try {
+    response = await fetch(`${MAPBOX_SUGGEST_ENDPOINT}?${queryString}`, {
+      signal,
+    });
+  } catch (error) {
+    throw toMapboxApiError("suggest", error);
   }
 
-  const data = (await response.json()) as MapboxSuggestResponse;
+  if (!response.ok) {
+    throw createMapboxHttpStatusError("suggest", response.status);
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    throw createMapboxInvalidResponseError(
+      "suggest",
+      "Mapbox suggest response was not valid JSON",
+    );
+  }
+
+  if (!isMapboxSuggestResponse(data)) {
+    throw createMapboxInvalidResponseError(
+      "suggest",
+      "Mapbox suggest response shape was invalid",
+    );
+  }
+
   const suggestions = data.suggestions ?? [];
   const mappedSuggestions = suggestions.map((suggestion) =>
     toLocationSuggestion(suggestion, sessionToken),

--- a/frontend/src/components/home/FiltersSection.tsx
+++ b/frontend/src/components/home/FiltersSection.tsx
@@ -19,7 +19,10 @@ import {
   type SportType,
 } from "@/domain/sport";
 import { CONTENT_GAP } from "@/config/uiLayout";
-import { useHomeLocationSuggest } from "@/hooks/useHomeLocationSuggest";
+import {
+  useHomeLocationSuggest,
+  type LocationSuggestErrorReason,
+} from "@/hooks/useHomeLocationSuggest";
 import { useHomeStore } from "@/store/homeStore";
 import { SectionCard } from "@/components/ui/SectionCard";
 import { toPublicAssetUrl } from "@/lib/publicAssetUrl";
@@ -32,10 +35,14 @@ interface SelectOption<T extends string = string> {
 const FIELD_LABEL_WIDTH = 72;
 const SPORT_IMAGE_HEIGHT = 104;
 
+interface FiltersSectionProps {
+  onLocationError?: (reason: LocationSuggestErrorReason) => void;
+}
+
 /**
  * Renders sport and location filters for Home risk calculation.
  */
-export function FiltersSection() {
+export function FiltersSection({ onLocationError }: FiltersSectionProps) {
   const { t } = useTranslation();
   const locationCombobox = useCombobox();
   /*
@@ -86,6 +93,7 @@ export function FiltersSection() {
     locationSuggestions,
     isSuggestLoading,
     shouldOpenLocationDropdown,
+    suggestErrorReason,
     onLocationSearchInputChange,
     onLocationOptionSubmit,
   } = useHomeLocationSuggest();
@@ -113,6 +121,12 @@ export function FiltersSection() {
     shouldOpenLocationDropdown,
     shouldRenderLocationDropdown,
   ]);
+
+  useEffect(() => {
+    if (suggestErrorReason) {
+      onLocationError?.(suggestErrorReason);
+    }
+  }, [onLocationError, suggestErrorReason]);
 
   /*
   const handleProfileChange = (value: string | null) => {

--- a/frontend/src/components/ui/BottomToast.tsx
+++ b/frontend/src/components/ui/BottomToast.tsx
@@ -1,37 +1,35 @@
 import { Box, Notification, Portal } from "@mantine/core";
+import { IconAlertTriangle, IconCheck } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
-const TOAST_HIDE_AFTER_MS = 2800;
-const CHECK_ICON = (
-  <svg
-    viewBox="0 0 16 16"
-    width="16"
-    height="16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path
-      d="M3.5 8.5L6.5 11.5L12.5 4.5"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
+const DEFAULT_TOAST_HIDE_AFTER_MS = 2800;
+
+export type BottomToastVariant = "success" | "error";
 
 interface BottomToastProps {
   eventId: number;
   message: string;
+  variant?: BottomToastVariant;
+  durationMs?: number;
 }
 
 /**
- * Renders a small bottom toast for transient background update feedback.
+ * Renders a small bottom toast for transient Home notifications.
  */
-export function BottomToast({ eventId, message }: BottomToastProps) {
+export function BottomToast({
+  eventId,
+  message,
+  variant = "success",
+  durationMs = DEFAULT_TOAST_HIDE_AFTER_MS,
+}: BottomToastProps) {
   const [dismissedEventId, setDismissedEventId] = useState(0);
   const isVisible = eventId > dismissedEventId;
+  const isError = variant === "error";
+  const icon = isError ? (
+    <IconAlertTriangle size={16} stroke={2} aria-hidden="true" />
+  ) : (
+    <IconCheck size={16} stroke={2} aria-hidden="true" />
+  );
 
   useEffect(() => {
     if (!isVisible) {
@@ -40,12 +38,12 @@ export function BottomToast({ eventId, message }: BottomToastProps) {
 
     const timeoutId = window.setTimeout(() => {
       setDismissedEventId(eventId);
-    }, TOAST_HIDE_AFTER_MS);
+    }, durationMs);
 
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [eventId, isVisible]);
+  }, [durationMs, eventId, isVisible]);
 
   if (!isVisible) {
     return null;
@@ -65,11 +63,11 @@ export function BottomToast({ eventId, message }: BottomToastProps) {
         }}
       >
         <Notification
-          role="status"
-          aria-live="polite"
+          role={isError ? "alert" : "status"}
+          aria-live={isError ? "assertive" : "polite"}
           withCloseButton={false}
-          icon={CHECK_ICON}
-          color="teal"
+          icon={icon}
+          color={isError ? "red" : "teal"}
           title={message}
           mt="md"
           w="100%"
@@ -90,6 +88,7 @@ export function BottomToast({ eventId, message }: BottomToastProps) {
               marginBottom: 0,
               textAlign: "left",
               lineHeight: "1.2",
+              whiteSpace: "pre-line",
             },
             description: {
               display: "none",

--- a/frontend/src/domain/homeErrorMap.test.ts
+++ b/frontend/src/domain/homeErrorMap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  toCalculationErrorI18nKey,
+  toSuggestErrorI18nKey,
+  type HomeCalculationErrorReason,
+  type HomeSuggestErrorReason,
+} from "@/domain/homeErrorMap";
+
+describe("homeErrorMap", () => {
+  it("maps location suggest error reasons to user-facing copy keys", () => {
+    const expected: Record<HomeSuggestErrorReason, string> = {
+      missing_token: "errors.mapbox.missingToken",
+      unavailable: "errors.mapbox.unavailable",
+      no_results: "errors.mapbox.noResults",
+      retrieve_failed: "errors.mapbox.retrieveFailed",
+      prefilled_location_not_matched: "errors.location.prefilledNotMatched",
+    };
+
+    for (const [reason, i18nKey] of Object.entries(expected)) {
+      expect(toSuggestErrorI18nKey(reason as HomeSuggestErrorReason)).toBe(
+        i18nKey,
+      );
+    }
+  });
+
+  it("maps heat-risk calculation error reasons to user-facing copy keys", () => {
+    const expected: Record<HomeCalculationErrorReason, string> = {
+      missing_location_coordinates: "errors.location.missingCoordinates",
+      missing_config: "errors.risk.missingApiBaseUrl",
+      abort: "errors.risk.network",
+      http_status: "errors.risk.network",
+      invalid_response: "errors.risk.invalidResponse",
+      network: "errors.risk.network",
+      weather_provider_unavailable: "errors.risk.weatherProvider",
+    };
+
+    for (const [reason, i18nKey] of Object.entries(expected)) {
+      expect(
+        toCalculationErrorI18nKey(reason as HomeCalculationErrorReason),
+      ).toBe(i18nKey);
+    }
+  });
+});

--- a/frontend/src/domain/homeErrorMap.ts
+++ b/frontend/src/domain/homeErrorMap.ts
@@ -11,7 +11,8 @@ export type HomeCalculationErrorReason =
   | "abort"
   | "http_status"
   | "invalid_response"
-  | "network";
+  | "network"
+  | "weather_provider_unavailable";
 
 const SUGGEST_ERROR_I18N_KEY_BY_REASON: Record<HomeSuggestErrorReason, string> =
   {
@@ -32,6 +33,7 @@ const CALCULATION_ERROR_I18N_KEY_BY_REASON: Record<
   http_status: "errors.risk.network",
   invalid_response: "errors.risk.invalidResponse",
   network: "errors.risk.network",
+  weather_provider_unavailable: "errors.risk.weatherProvider",
 };
 
 /**

--- a/frontend/src/domain/homeErrorMap.ts
+++ b/frontend/src/domain/homeErrorMap.ts
@@ -7,9 +7,11 @@ export type HomeSuggestErrorReason =
 
 export type HomeCalculationErrorReason =
   | "missing_location_coordinates"
-  | "missing_api_base_url"
+  | "missing_config"
+  | "abort"
+  | "http_status"
   | "invalid_response"
-  | "network_error";
+  | "network";
 
 const SUGGEST_ERROR_I18N_KEY_BY_REASON: Record<HomeSuggestErrorReason, string> =
   {
@@ -25,9 +27,11 @@ const CALCULATION_ERROR_I18N_KEY_BY_REASON: Record<
   string
 > = {
   missing_location_coordinates: "errors.location.missingCoordinates",
-  missing_api_base_url: "errors.risk.missingApiBaseUrl",
+  missing_config: "errors.risk.missingApiBaseUrl",
+  abort: "errors.risk.network",
+  http_status: "errors.risk.network",
   invalid_response: "errors.risk.invalidResponse",
-  network_error: "errors.risk.network",
+  network: "errors.risk.network",
 };
 
 /**

--- a/frontend/src/hooks/homeLocationRetrieve.test.ts
+++ b/frontend/src/hooks/homeLocationRetrieve.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/api/apiErrors";
+import { MapboxApiError } from "@/api/mapboxErrors";
+import { retrieveLocationCoordinates } from "@/api/mapboxRetrieve";
+import type { LocationSuggestion } from "@/domain/location";
+import type { AbortableRequestHandle } from "@/lib/latestAbortableRequest";
+import { retrieveAndSelectLocation } from "@/hooks/homeLocationRetrieve";
+
+vi.mock("@/api/mapboxRetrieve", () => ({
+  retrieveLocationCoordinates: vi.fn(),
+}));
+
+const retrieveLocationCoordinatesMock = vi.mocked(retrieveLocationCoordinates);
+
+const SYDNEY_SUGGESTION: LocationSuggestion = {
+  id: "place-sydney",
+  displayLabel: "Sydney, New South Wales, Australia",
+  name: "Sydney",
+  regionName: "New South Wales",
+  countryName: "Australia",
+  mapboxId: "place-sydney",
+  countryCode: "AU",
+  sessionToken: "session-sydney",
+};
+
+function createRequestHandle(isCurrent = true): AbortableRequestHandle {
+  const abortController = new AbortController();
+
+  return {
+    signal: abortController.signal,
+    isCurrent: () => isCurrent,
+    finish: vi.fn(),
+  };
+}
+
+describe("retrieveAndSelectLocation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("selects the location with retrieved coordinates for the current request", async () => {
+    retrieveLocationCoordinatesMock.mockResolvedValue({
+      latitude: -33.847,
+      longitude: 151.067,
+    });
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(retrieveLocationCoordinatesMock).toHaveBeenCalledWith({
+      mapboxId: "place-sydney",
+      accessToken: "token",
+      sessionToken: "session-sydney",
+      signal: request.signal,
+    });
+    expect(setHasRetrieveError).toHaveBeenCalledWith(false);
+    expect(selectLocation).toHaveBeenCalledWith({
+      ...SYDNEY_SUGGESTION,
+      latitude: -33.847,
+      longitude: 151.067,
+    });
+    expect(request.finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not select stale retrieve results", async () => {
+    retrieveLocationCoordinatesMock.mockResolvedValue({
+      latitude: -33.847,
+      longitude: 151.067,
+    });
+    const request = createRequestHandle(false);
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(setHasRetrieveError).not.toHaveBeenCalled();
+    expect(request.finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a retrieve error when the suggestion is missing a Mapbox id", async () => {
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: {
+        ...SYDNEY_SUGGESTION,
+        mapboxId: undefined,
+      },
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(setHasRetrieveError).toHaveBeenCalledWith(true);
+    expect(retrieveLocationCoordinatesMock).not.toHaveBeenCalled();
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(request.finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a retrieve error when the suggestion is missing a session token", async () => {
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: {
+        ...SYDNEY_SUGGESTION,
+        sessionToken: undefined,
+      },
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(setHasRetrieveError).toHaveBeenCalledWith(true);
+    expect(retrieveLocationCoordinatesMock).not.toHaveBeenCalled();
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(request.finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a retrieve error when the Mapbox token is unavailable", async () => {
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: false,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(setHasRetrieveError).toHaveBeenCalledWith(true);
+    expect(retrieveLocationCoordinatesMock).not.toHaveBeenCalled();
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(request.finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark a retrieve error when a guard failure is stale", async () => {
+    const request = createRequestHandle(false);
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: {
+        ...SYDNEY_SUGGESTION,
+        mapboxId: undefined,
+      },
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(setHasRetrieveError).not.toHaveBeenCalled();
+    expect(retrieveLocationCoordinatesMock).not.toHaveBeenCalled();
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(request.finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks retrieve errors without selecting a location", async () => {
+    retrieveLocationCoordinatesMock.mockRejectedValue(
+      new MapboxApiError({
+        endpoint: "retrieve",
+        kind: "invalid_response",
+        message: "bad payload",
+      }),
+    );
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(setHasRetrieveError).toHaveBeenCalledWith(true);
+    expect(retrieveLocationCoordinatesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores aborts without marking a retrieve error", async () => {
+    retrieveLocationCoordinatesMock.mockRejectedValue(
+      new ApiError({
+        kind: "abort",
+        message: "cancelled",
+      }),
+    );
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(setHasRetrieveError).not.toHaveBeenCalled();
+  });
+
+  it("retries one transient retrieve failure before selecting the location", async () => {
+    vi.useFakeTimers();
+    retrieveLocationCoordinatesMock
+      .mockRejectedValueOnce(
+        new MapboxApiError({
+          endpoint: "retrieve",
+          kind: "network",
+          message: "offline",
+        }),
+      )
+      .mockResolvedValueOnce({
+        latitude: -33.847,
+        longitude: 151.067,
+      });
+    const request = createRequestHandle();
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    const retrievePromise = retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    await vi.runAllTimersAsync();
+    await retrievePromise;
+
+    expect(retrieveLocationCoordinatesMock).toHaveBeenCalledTimes(2);
+    expect(setHasRetrieveError).toHaveBeenCalledWith(false);
+    expect(selectLocation).toHaveBeenCalledWith({
+      ...SYDNEY_SUGGESTION,
+      latitude: -33.847,
+      longitude: 151.067,
+    });
+  });
+
+  it("does not retry a transient retrieve failure after the request becomes stale", async () => {
+    let isCurrent = true;
+    retrieveLocationCoordinatesMock.mockImplementationOnce(async () => {
+      isCurrent = false;
+      throw new MapboxApiError({
+        endpoint: "retrieve",
+        kind: "network",
+        message: "offline",
+      });
+    });
+    const request: AbortableRequestHandle = {
+      signal: new AbortController().signal,
+      isCurrent: () => isCurrent,
+      finish: vi.fn(),
+    };
+    const selectLocation = vi.fn();
+    const setHasRetrieveError = vi.fn();
+
+    await retrieveAndSelectLocation({
+      selectedSuggestion: SYDNEY_SUGGESTION,
+      hasMapboxToken: true,
+      mapboxAccessToken: "token",
+      request,
+      selectLocation,
+      setHasRetrieveError,
+    });
+
+    expect(retrieveLocationCoordinatesMock).toHaveBeenCalledTimes(1);
+    expect(selectLocation).not.toHaveBeenCalled();
+    expect(setHasRetrieveError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/homeLocationRetrieve.ts
+++ b/frontend/src/hooks/homeLocationRetrieve.ts
@@ -1,0 +1,75 @@
+import { isAbortApiError } from "@/api/apiErrors";
+import {
+  mapboxRetrieveRetryPolicy,
+  retryApiRequest,
+} from "@/api/apiRetryPolicy";
+import { retrieveLocationCoordinates } from "@/api/mapboxRetrieve";
+import type { LocationSuggestion } from "@/domain/location";
+import type { AbortableRequestHandle } from "@/lib/latestAbortableRequest";
+
+export interface RetrieveAndSelectLocationParams {
+  selectedSuggestion: LocationSuggestion;
+  hasMapboxToken: boolean;
+  mapboxAccessToken: string;
+  request: AbortableRequestHandle;
+  selectLocation: (suggestion: LocationSuggestion) => void;
+  setHasRetrieveError: (hasError: boolean) => void;
+}
+
+/**
+ * Retrieves coordinates for a Mapbox suggestion and commits only current results.
+ */
+export async function retrieveAndSelectLocation({
+  selectedSuggestion,
+  hasMapboxToken,
+  mapboxAccessToken,
+  request,
+  selectLocation,
+  setHasRetrieveError,
+}: RetrieveAndSelectLocationParams): Promise<void> {
+  const mapboxId = selectedSuggestion.mapboxId;
+  const sessionToken = selectedSuggestion.sessionToken;
+
+  if (!mapboxId || !sessionToken || !hasMapboxToken) {
+    if (request.isCurrent()) {
+      setHasRetrieveError(true);
+    }
+    request.finish();
+    return;
+  }
+
+  try {
+    const coordinates = await retryApiRequest(
+      () =>
+        retrieveLocationCoordinates({
+          mapboxId,
+          accessToken: mapboxAccessToken,
+          sessionToken,
+          signal: request.signal,
+        }),
+      mapboxRetrieveRetryPolicy,
+      {
+        canContinue: request.isCurrent,
+      },
+    );
+
+    if (!request.isCurrent()) {
+      return;
+    }
+
+    setHasRetrieveError(false);
+    selectLocation({
+      ...selectedSuggestion,
+      latitude: coordinates.latitude,
+      longitude: coordinates.longitude,
+    });
+  } catch (error) {
+    if (!request.isCurrent() || isAbortApiError(error)) {
+      return;
+    }
+
+    setHasRetrieveError(true);
+  } finally {
+    request.finish();
+  }
+}

--- a/frontend/src/hooks/useHomeHeatRisk.ts
+++ b/frontend/src/hooks/useHomeHeatRisk.ts
@@ -1,11 +1,8 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@mantine/hooks";
-import {
-  buildHeatRiskRequest,
-  fetchHeatRisk,
-  type HeatRiskApiResponse,
-  type HeatRiskErrorReason,
-} from "@/api/heatRisk";
+import { ApiError, isApiError } from "@/api/apiErrors";
+import { getRetryDelayMs, heatRiskRetryPolicy } from "@/api/apiRetryPolicy";
+import { fetchHeatRisk, type HeatRiskApiResponse } from "@/api/heatRisk";
 import type { HomeCalculationErrorReason } from "@/domain/homeErrorMap";
 import type { ForecastDay, HeatRisk, RiskLevel } from "@/domain/risk";
 import { toRiskLevel } from "@/domain/risk";
@@ -20,16 +17,6 @@ import {
 import { useHomeStore } from "@/store/homeStore";
 
 export type HeatRiskCalculationErrorReason = HomeCalculationErrorReason;
-
-class HeatRiskQueryError extends Error {
-  reason: HeatRiskErrorReason;
-
-  constructor(reason: HeatRiskErrorReason) {
-    super(reason);
-    this.reason = reason;
-    this.name = "HeatRiskQueryError";
-  }
-}
 
 interface UseHomeHeatRiskBaseResult {
   forecast: ForecastDay[];
@@ -102,31 +89,41 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
     ],
     queryFn: async ({ signal }) => {
       const result = await fetchHeatRisk(
-        buildHeatRiskRequest({
+        {
           sport: debouncedSport,
           latitude: locationCoordinates!.latitude,
           longitude: locationCoordinates!.longitude,
           profile: debouncedProfile,
-        }),
+        },
         { signal },
       );
 
       if (!result.ok) {
-        throw new HeatRiskQueryError(result.reason);
+        throw new ApiError({
+          kind: result.reason,
+          status: result.status,
+          message: result.reason,
+        });
       }
 
       return result;
     },
     enabled: Boolean(locationCoordinates),
     placeholderData: keepPreviousData,
-    retry: false,
+    retry: (failureCount, error) =>
+      failureCount < heatRiskRetryPolicy.maxRetries &&
+      heatRiskRetryPolicy.shouldRetry(error),
+    retryDelay: () => getRetryDelayMs({ scope: "heat_risk" }),
+    staleTime: 0,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: false,
   });
 
   const errorReason: HeatRiskCalculationErrorReason | null =
     selectedLocation && !locationCoordinates
       ? "missing_location_coordinates"
-      : riskQuery.error instanceof HeatRiskQueryError
-        ? riskQuery.error.reason
+      : isApiError(riskQuery.error)
+        ? riskQuery.error.kind
         : null;
 
   const calculated = riskQuery.data

--- a/frontend/src/hooks/useHomeHeatRisk.ts
+++ b/frontend/src/hooks/useHomeHeatRisk.ts
@@ -62,6 +62,18 @@ function toCalculatedHeatRisk(data: HeatRiskApiResponse): {
   };
 }
 
+function toHeatRiskCalculationErrorReason(
+  error: unknown,
+): HeatRiskCalculationErrorReason | null {
+  if (!isApiError(error)) {
+    return null;
+  }
+
+  return error.serverCode === "weather_provider_unavailable"
+    ? "weather_provider_unavailable"
+    : error.kind;
+}
+
 /**
  * Auto-fetches heat risk for the selected Home sport + location.
  *
@@ -100,8 +112,15 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
 
       if (!result.ok) {
         throw new ApiError({
-          kind: result.reason,
+          kind:
+            result.reason === "weather_provider_unavailable"
+              ? "http_status"
+              : result.reason,
           status: result.status,
+          serverCode:
+            result.reason === "weather_provider_unavailable"
+              ? "weather_provider_unavailable"
+              : undefined,
           message: result.reason,
         });
       }
@@ -122,9 +141,7 @@ export function useHomeHeatRisk(): UseHomeHeatRiskResult {
   const errorReason: HeatRiskCalculationErrorReason | null =
     selectedLocation && !locationCoordinates
       ? "missing_location_coordinates"
-      : isApiError(riskQuery.error)
-        ? riskQuery.error.kind
-        : null;
+      : toHeatRiskCalculationErrorReason(riskQuery.error);
 
   const calculated = riskQuery.data
     ? toCalculatedHeatRisk(riskQuery.data.data)

--- a/frontend/src/hooks/useHomeLocationSuggest.ts
+++ b/frontend/src/hooks/useHomeLocationSuggest.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@mantine/hooks";
 import { useEffect, useMemo, useState } from "react";
-import { retrieveLocationCoordinates } from "@/api/mapboxRetrieve";
 import { suggestLocations } from "@/api/mapboxSuggest";
 import type { HomeSuggestErrorReason } from "@/domain/homeErrorMap";
 import type { LocationSuggestion } from "@/domain/location";
@@ -12,6 +11,8 @@ import {
   shouldOpenPrefilledLocationDropdown,
   toPrefilledLocationSuggestQuery,
 } from "@/domain/locationSearch";
+import { createLatestAbortableRequestController } from "@/lib/latestAbortableRequest";
+import { retrieveAndSelectLocation } from "@/hooks/homeLocationRetrieve";
 import { useHomeStore } from "@/store/homeStore";
 
 const MIN_LOCATION_QUERY_LENGTH = 2;
@@ -118,45 +119,6 @@ function findSubmittedSuggestion(
   );
 }
 
-async function retrieveAndSelectLocation(params: {
-  selectedSuggestion: LocationSuggestion;
-  hasMapboxToken: boolean;
-  mapboxAccessToken: string;
-  selectLocation: (suggestion: LocationSuggestion) => void;
-  setHasRetrieveError: (hasError: boolean) => void;
-}): Promise<void> {
-  const {
-    selectedSuggestion,
-    hasMapboxToken,
-    mapboxAccessToken,
-    selectLocation,
-    setHasRetrieveError,
-  } = params;
-  const mapboxId = selectedSuggestion.mapboxId;
-  const sessionToken = selectedSuggestion.sessionToken;
-
-  if (!mapboxId || !sessionToken || !hasMapboxToken) {
-    setHasRetrieveError(true);
-    return;
-  }
-
-  try {
-    const coordinates = await retrieveLocationCoordinates({
-      mapboxId,
-      accessToken: mapboxAccessToken,
-      sessionToken,
-    });
-    setHasRetrieveError(false);
-    selectLocation({
-      ...selectedSuggestion,
-      latitude: coordinates.latitude,
-      longitude: coordinates.longitude,
-    });
-  } catch {
-    setHasRetrieveError(true);
-  }
-}
-
 /**
  * Query-driven location suggest hook for Home.
  */
@@ -193,6 +155,10 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     (state) => state.markPrefilledLocationNotMatched,
   );
   const [hasRetrieveError, setHasRetrieveError] = useState(false);
+  const retrieveController = useMemo(
+    () => createLatestAbortableRequestController(),
+    [],
+  );
 
   const query = locationSearchInput.trim();
   const selectedLocationValue = selectedLocation?.displayLabel.trim() ?? "";
@@ -244,12 +210,18 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
       });
     },
     enabled: shouldSuggest,
+    retry: false,
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
 
   const dedupedSuggestions =
     suggestQuery.data?.dedupedSuggestions ?? EMPTY_SUGGESTIONS;
   const visibleSuggestions =
     suggestQuery.data?.visibleSuggestions ?? EMPTY_SUGGESTIONS;
+
+  useEffect(() => () => retrieveController.cancel(), [retrieveController]);
 
   useEffect(() => {
     if (!isPrefilledLocationResolvePending) {
@@ -286,6 +258,7 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
       selectedSuggestion,
       hasMapboxToken,
       mapboxAccessToken,
+      request: retrieveController.start(),
       selectLocation,
       setHasRetrieveError,
     }).finally(() => {
@@ -303,6 +276,7 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     query,
     queryForRequest,
     dedupedSuggestions,
+    retrieveController,
     selectLocation,
     selectedLocation,
     startPrefilledLocationResolve,
@@ -329,6 +303,8 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
     });
 
   const onLocationSearchInputChange = (value: string) => {
+    retrieveController.cancel();
+
     if (hasRetrieveError) {
       setHasRetrieveError(false);
     }
@@ -355,6 +331,7 @@ export function useHomeLocationSuggest(): UseHomeLocationSuggestResult {
       selectedSuggestion,
       hasMapboxToken,
       mapboxAccessToken,
+      request: retrieveController.start(),
       selectLocation,
       setHasRetrieveError,
     }).finally(() => {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -236,7 +236,7 @@
   },
   "home": {
     "notifications": {
-      "forecastUpdated": "Forecast data has been updated"
+      "forecastUpdated": "Forecast updated"
     },
     "sections": {
       "filters": {
@@ -281,19 +281,20 @@
   },
   "errors": {
     "mapbox": {
-      "missingToken": "Mapbox access token is required to search locations. Please configure VITE_MAPBOX_ACCESS_TOKEN.",
-      "unavailable": "Location suggestions are temporarily unavailable. Please try again.",
-      "noResults": "No location found for this query.",
-      "retrieveFailed": "Unable to resolve coordinates for the selected location. Please try another suggestion."
+      "missingToken": "Location search is not configured.\nSet VITE_MAPBOX_ACCESS_TOKEN.",
+      "unavailable": "Location provider is unavailable.\nTry again soon.",
+      "noResults": "No matching location found.",
+      "retrieveFailed": "Location provider failed.\nTry again soon."
     },
     "location": {
-      "missingCoordinates": "Selected location is missing coordinates. Please select a suggestion again.",
-      "prefilledNotMatched": "Unable to auto-match this prefilled location. Please select a suggestion manually."
+      "missingCoordinates": "This location has no coordinates. Choose another suggestion.",
+      "prefilledNotMatched": "Please choose a location from the suggestions."
     },
     "risk": {
-      "missingApiBaseUrl": "Risk API is not configured. Set VITE_API_BASE_URL.",
-      "invalidResponse": "Risk API returned an invalid response. Please try again.",
-      "network": "Risk calculation is temporarily unavailable. Please try again."
+      "missingApiBaseUrl": "Risk API is not configured.\nSet VITE_API_BASE_URL.",
+      "invalidResponse": "Risk data could not be loaded.",
+      "network": "Risk calculation is unavailable.\nTry again soon.",
+      "weatherProvider": "Weather provider is unavailable.\nTry again soon."
     }
   },
   "providers": {

--- a/frontend/src/lib/latestAbortableRequest.test.ts
+++ b/frontend/src/lib/latestAbortableRequest.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createLatestAbortableRequestController } from "@/lib/latestAbortableRequest";
+
+describe("createLatestAbortableRequestController", () => {
+  it("aborts the previous request and marks it stale when a newer request starts", () => {
+    const controller = createLatestAbortableRequestController();
+
+    const first = controller.start();
+    const second = controller.start();
+
+    expect(first.signal.aborted).toBe(true);
+    expect(first.isCurrent()).toBe(false);
+    expect(second.signal.aborted).toBe(false);
+    expect(second.isCurrent()).toBe(true);
+  });
+
+  it("marks a request stale when user input cancels the active retrieve", () => {
+    const controller = createLatestAbortableRequestController();
+
+    const request = controller.start();
+    controller.cancel();
+
+    expect(request.signal.aborted).toBe(true);
+    expect(request.isCurrent()).toBe(false);
+  });
+
+  it("only lets the current request clear itself on finish", () => {
+    const controller = createLatestAbortableRequestController();
+
+    const first = controller.start();
+    const second = controller.start();
+
+    first.finish();
+    expect(second.isCurrent()).toBe(true);
+
+    second.finish();
+    expect(second.isCurrent()).toBe(false);
+  });
+});

--- a/frontend/src/lib/latestAbortableRequest.ts
+++ b/frontend/src/lib/latestAbortableRequest.ts
@@ -1,0 +1,44 @@
+export interface AbortableRequestHandle {
+  signal: AbortSignal;
+  isCurrent: () => boolean;
+  finish: () => void;
+}
+
+export interface LatestAbortableRequestController {
+  start: () => AbortableRequestHandle;
+  cancel: () => void;
+}
+
+/**
+ * Creates a small controller that keeps only the newest abortable request current.
+ */
+export function createLatestAbortableRequestController(): LatestAbortableRequestController {
+  let nextId = 0;
+  let current: { id: number; controller: AbortController } | null = null;
+
+  return {
+    start: () => {
+      current?.controller.abort();
+
+      const id = nextId + 1;
+      nextId = id;
+      const controller = new AbortController();
+      current = { id, controller };
+
+      return {
+        signal: controller.signal,
+        isCurrent: () => current?.id === id && !controller.signal.aborted,
+        finish: () => {
+          if (current?.id === id) {
+            current = null;
+          }
+        },
+      };
+    },
+    cancel: () => {
+      current?.controller.abort();
+      current = null;
+      nextId += 1;
+    },
+  };
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,11 @@
 import { Stack } from "@mantine/core";
-import { useEffect, useEffectEvent, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
 import { CurrentRiskSection } from "@/components/home/CurrentRiskSection";
 import { FiltersSection } from "@/components/home/FiltersSection";
 import { ForecastSection } from "@/components/home/ForecastSection";
@@ -9,6 +15,13 @@ import { BottomToast } from "@/components/ui/BottomToast";
 import { SECTION_STACK_GAP } from "@/config/uiLayout";
 import { useHomeHeatRisk } from "@/hooks/useHomeHeatRisk";
 import { useHomeUrlSync } from "@/hooks/useHomeUrlSync";
+import type { HomeSuggestErrorReason } from "@/domain/homeErrorMap";
+import {
+  createCalculationErrorToast,
+  createForecastUpdatedToast,
+  createSuggestErrorToast,
+  type HomeToastEvent,
+} from "@/pages/home/homeToast";
 import { useHomeBootstrap } from "@/pages/home/useHomeBootstrap";
 import { useHomeStore } from "@/store/homeStore";
 import { useTranslation } from "react-i18next";
@@ -21,18 +34,46 @@ const HOME_AUTO_REFRESH_INTERVAL_MS = 20 * 60 * 1000;
 export function HomePage() {
   const { t } = useTranslation();
   const { setQueryStates } = useHomeBootstrap();
-  const { canSyncSelection, hasCalculatedRisk, refresh } = useHomeHeatRisk();
+  const { canSyncSelection, errorReason, hasCalculatedRisk, refresh } =
+    useHomeHeatRisk();
   const profile = useHomeStore((state) => state.profile);
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
-  const [refreshToastEventId, setRefreshToastEventId] = useState(0);
+  const [toastEvent, setToastEvent] = useState<HomeToastEvent | null>(null);
+  const nextToastEventIdRef = useRef(0);
 
   useHomeUrlSync({
     setQueryStates,
     canSyncSelection,
   });
 
+  const publishToast = useCallback(
+    (createToast: (id: number) => HomeToastEvent | null) => {
+      const nextToastEventId = nextToastEventIdRef.current + 1;
+      const nextToastEvent = createToast(nextToastEventId);
+
+      if (!nextToastEvent) {
+        return;
+      }
+
+      nextToastEventIdRef.current = nextToastEventId;
+      setToastEvent(nextToastEvent);
+    },
+    [],
+  );
+  const handleLocationError = useCallback(
+    (reason: HomeSuggestErrorReason) => {
+      publishToast((id) => createSuggestErrorToast(id, reason));
+    },
+    [publishToast],
+  );
   const runScheduledRefresh = useEffectEvent(async () => refresh());
+
+  useEffect(() => {
+    if (errorReason) {
+      publishToast((id) => createCalculationErrorToast(id, errorReason));
+    }
+  }, [errorReason, publishToast]);
 
   useEffect(() => {
     if (!(selectedLocation !== null && Boolean(sport) && hasCalculatedRisk)) {
@@ -51,7 +92,7 @@ export function HomePage() {
         }
 
         if (didRefresh) {
-          setRefreshToastEventId((currentId) => currentId + 1);
+          publishToast(createForecastUpdatedToast);
         }
 
         scheduleNextRefresh();
@@ -67,21 +108,25 @@ export function HomePage() {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [hasCalculatedRisk, profile, selectedLocation, sport]);
+  }, [hasCalculatedRisk, profile, publishToast, selectedLocation, sport]);
 
   return (
     <>
       <Stack gap={SECTION_STACK_GAP}>
-        <FiltersSection />
+        <FiltersSection onLocationError={handleLocationError} />
         <CurrentRiskSection />
         <CurrentRiskRecommendationsSection />
         <ForecastSection />
         <LocationMapSection />
       </Stack>
-      <BottomToast
-        eventId={refreshToastEventId}
-        message={t("home.notifications.forecastUpdated")}
-      />
+      {toastEvent ? (
+        <BottomToast
+          eventId={toastEvent.id}
+          message={t(toastEvent.i18nKey)}
+          variant={toastEvent.variant}
+          durationMs={toastEvent.durationMs}
+        />
+      ) : null}
     </>
   );
 }

--- a/frontend/src/pages/home/homeToast.test.ts
+++ b/frontend/src/pages/home/homeToast.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCalculationErrorToast,
+  createForecastUpdatedToast,
+  createSuggestErrorToast,
+  HOME_ERROR_TOAST_DURATION_MS,
+  HOME_SUCCESS_TOAST_DURATION_MS,
+} from "@/pages/home/homeToast";
+
+describe("homeToast", () => {
+  it("creates a short success toast for refreshed forecasts", () => {
+    expect(createForecastUpdatedToast(7)).toEqual({
+      id: 7,
+      i18nKey: "home.notifications.forecastUpdated",
+      variant: "success",
+      durationMs: HOME_SUCCESS_TOAST_DURATION_MS,
+    });
+  });
+
+  it("creates a longer error toast for weather provider failures", () => {
+    expect(
+      createCalculationErrorToast(8, "weather_provider_unavailable"),
+    ).toEqual({
+      id: 8,
+      i18nKey: "errors.risk.weatherProvider",
+      variant: "error",
+      durationMs: HOME_ERROR_TOAST_DURATION_MS,
+    });
+  });
+
+  it("creates a longer error toast for location retrieve failures", () => {
+    expect(createSuggestErrorToast(9, "retrieve_failed")).toEqual({
+      id: 9,
+      i18nKey: "errors.mapbox.retrieveFailed",
+      variant: "error",
+      durationMs: HOME_ERROR_TOAST_DURATION_MS,
+    });
+  });
+
+  it("does not create a toast without an error reason", () => {
+    expect(createCalculationErrorToast(10, null)).toBeNull();
+    expect(createSuggestErrorToast(11, null)).toBeNull();
+  });
+});

--- a/frontend/src/pages/home/homeToast.ts
+++ b/frontend/src/pages/home/homeToast.ts
@@ -1,0 +1,63 @@
+import {
+  toCalculationErrorI18nKey,
+  toSuggestErrorI18nKey,
+  type HomeCalculationErrorReason,
+  type HomeSuggestErrorReason,
+} from "@/domain/homeErrorMap";
+
+export type HomeToastVariant = "success" | "error";
+
+export interface HomeToastEvent {
+  id: number;
+  i18nKey: string;
+  variant: HomeToastVariant;
+  durationMs: number;
+}
+
+export const HOME_SUCCESS_TOAST_DURATION_MS = 3000;
+export const HOME_ERROR_TOAST_DURATION_MS = 5000;
+
+export function createForecastUpdatedToast(id: number): HomeToastEvent {
+  return {
+    id,
+    i18nKey: "home.notifications.forecastUpdated",
+    variant: "success",
+    durationMs: HOME_SUCCESS_TOAST_DURATION_MS,
+  };
+}
+
+export function createCalculationErrorToast(
+  id: number,
+  reason: HomeCalculationErrorReason | null,
+): HomeToastEvent | null {
+  const i18nKey = toCalculationErrorI18nKey(reason);
+
+  if (!i18nKey) {
+    return null;
+  }
+
+  return {
+    id,
+    i18nKey,
+    variant: "error",
+    durationMs: HOME_ERROR_TOAST_DURATION_MS,
+  };
+}
+
+export function createSuggestErrorToast(
+  id: number,
+  reason: HomeSuggestErrorReason | null,
+): HomeToastEvent | null {
+  const i18nKey = toSuggestErrorI18nKey(reason);
+
+  if (!i18nKey) {
+    return null;
+  }
+
+  return {
+    id,
+    i18nKey,
+    variant: "error",
+    durationMs: HOME_ERROR_TOAST_DURATION_MS,
+  };
+}


### PR DESCRIPTION
## Summary

- Add structured frontend API and Mapbox errors for network, abort, HTTP status, invalid response, and missing config failures.
- Add bounded retry handling for transient heat-risk and Mapbox retrieve failures, with abort-safe location coordinate retrieval so stale requests cannot overwrite newer selections.
- Surface location and risk calculation failures through bottom toast notifications while preserving the last valid heat-risk result.
- Return a stable backend `weather_provider_unavailable` error code and map it to a weather-provider-specific frontend toast.
- Update toast UI, i18n copy, README notes, and focused tests for retry/error handling, Mapbox parsing, abortable requests, location retrieval, and toast creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured `error_code` support to backend error responses and frontend error handling
  * Introduced bounded retry policies for Mapbox and heat-risk requests
  * Improved latest-only, abortable location retrieval to prevent stale updates
  * Enhanced Home toasts with explicit success/error variants and configurable durations
* **Bug Fixes**
  * Weather-provider unavailability now returns a specific `weather_provider_unavailable` code in the API response
  * Refined handling for aborts vs network/server failures
* **Documentation**
  * Updated backend validation/error documentation and clarified that profile selection is reserved for a future release
* **Tests**
  * Expanded coverage for retry behavior, error mapping, and heat-risk/location flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->