### PR TITLE
chore: update Android asset link and policy PDF URL

### DIFF
--- a/frontend/public/.well-known/assetlinks.json
+++ b/frontend/public/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
       "namespace": "android_app",
       "package_name": "au.edu.sydney.sports_heat_tool.twa",
       "sha256_cert_fingerprints": [
-        "F9:72:97:47:1B:56:D3:2E:23:99:55:FC:8A:78:21:6E:D3:A8:86:CA:3F:CF:B7:8A:56:FC:18:53:E0:36:5C:BF"
+        "1F:C0:45:8F:68:77:97:63:2C:53:54:29:9D:B6:2C:57:28:61:73:71:DC:12:D1:14:C2:FD:7F:99:4D:A0:B4:4D"
       ]
     }
   }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -105,7 +105,7 @@
             "runs": [
               {
                 "text": "Extreme Heat Policy 2025",
-                "href": "https://sma.org.au/wp-content/uploads/2025/10/Extreme-Heat-Policy-2025_FIN.pdf"
+                "href": "https://sma.org.au/wp-content/uploads/2026/01/Extreme-Heat-Policy-2025_v1.pdf"
               }
             ]
           }


### PR DESCRIPTION
Update the TWA assetlinks certificate fingerprint and point the English policy link to the 2026-hosted Extreme Heat Policy PDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app security certificate configuration
  * Updated Extreme Heat Policy reference to the latest version (January 2026)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->