### PR TITLE
fix(frontend & backend): support pythermalcomfort 4.0.2 risk scale

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pandas==3.0.3",
     "pvlib==0.15.1",
     "pydantic-settings==2.14.1",
-    "pythermalcomfort==3.9.8",
+    "pythermalcomfort==4.0.2",
     "timezonefinder==8.2.4",
     "uvicorn[standard]==0.49.0",
 ]

--- a/backend/tests/api/test_home_risk.py
+++ b/backend/tests/api/test_home_risk.py
@@ -177,18 +177,19 @@ def test_post_home_risk_success_returns_forecast_centric_contract(profile: str) 
     }
 
 
-def test_forecast_heat_risk_accepts_legacy_scale_score() -> None:
+@pytest.mark.parametrize("score", [0.8, 4.9, 5.0])
+def test_forecast_heat_risk_accepts_finite_model_scores(score: float) -> None:
     """The public schema should continue accepting finite model scores."""
 
     heat_risk = ForecastHeatRisk(
-        risk_level_interpolated=0.8,
+        risk_level_interpolated=score,
         t_medium=34.5,
         t_high=37.1,
         t_extreme=39.2,
         recommendation="Increase hydration & modify clothing",
     )
 
-    assert heat_risk.risk_level_interpolated == 0.8
+    assert heat_risk.risk_level_interpolated == score
 
 
 def test_options_home_risk_allows_netlify_preview_origin_via_regex(monkeypatch) -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -452,7 +452,7 @@ wheels = [
 
 [[package]]
 name = "pythermalcomfort"
-version = "3.9.8"
+version = "4.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numba" },
@@ -460,9 +460,9 @@ dependencies = [
     { name = "scipy" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/71/9a60b8d311ab7c54a6fccaf2ec0bc61854cbebd869a7a8e079f09091ea8e/pythermalcomfort-3.9.8.tar.gz", hash = "sha256:e141787ef3b145f857d38b849d507f27becd9b41b14e3232f5c0122e176627c9", size = 484535, upload-time = "2026-05-26T02:07:55.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/58/8e88696f1faf6f46e86ce9f2ef249e3c1da9efbe9b9f532023b4476cea4d/pythermalcomfort-4.0.2.tar.gz", hash = "sha256:b8d6e2cafeca5e90a8709810aaabc92c2c653f22f75075baf9b353c299ec0df2", size = 2477800, upload-time = "2026-06-23T01:58:07.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/30/1fc9015177883d0a877c70d549d116236a83e764255e8a21cdebf09a2044/pythermalcomfort-3.9.8-py2.py3-none-any.whl", hash = "sha256:b5b2df237d567fc67f9ceb830b21deb2436e1c1a869ef50030239363305f4ca1", size = 238488, upload-time = "2026-05-26T02:07:53.661Z" },
+    { url = "https://files.pythonhosted.org/packages/46/08/7202431a30ea6b02002276bf6685ee86f8c9f548c6667cd01d6324df3e67/pythermalcomfort-4.0.2-py2.py3-none-any.whl", hash = "sha256:7d6c2bdcc7cc63f23057b09c3e55e973f65ad1e9e92fbb5a6c935f8576e9cfaf", size = 277031, upload-time = "2026-06-23T01:58:06.196Z" },
 ]
 
 [[package]]
@@ -621,7 +621,7 @@ requires-dist = [
     { name = "pandas", specifier = "==3.0.3" },
     { name = "pvlib", specifier = "==0.15.1" },
     { name = "pydantic-settings", specifier = "==2.14.1" },
-    { name = "pythermalcomfort", specifier = "==3.9.8" },
+    { name = "pythermalcomfort", specifier = "==4.0.2" },
     { name = "timezonefinder", specifier = "==8.2.4" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.49.0" },
 ]

--- a/frontend/src/domain/riskRegistry.test.ts
+++ b/frontend/src/domain/riskRegistry.test.ts
@@ -28,11 +28,14 @@ describe("getRiskBands", () => {
 });
 
 describe("toRiskDisplayScore", () => {
-  it("anchors the maximum model score to the high/extreme boundary", () => {
+  it("maps raw model scores onto the shifted display axis", () => {
     expect(toRiskDisplayScore(0.8)).toBe(0);
     expect(toRiskDisplayScore(1.5)).toBe(0.5);
     expect(toRiskDisplayScore(3.5)).toBe(2.5);
     expect(toRiskDisplayScore(4)).toBe(3);
+    expect(toRiskDisplayScore(4.9)).toBeCloseTo(3.9);
+    expect(toRiskDisplayScore(5)).toBe(4);
+    expect(toRiskDisplayScore(5.2)).toBe(4);
   });
 });
 

--- a/frontend/src/domain/riskRegistry.ts
+++ b/frontend/src/domain/riskRegistry.ts
@@ -28,7 +28,9 @@ export const RISK_LEVELS: readonly RiskLevel[] = [
   "high",
   "extreme",
 ] as const;
-export const MAX_RISK_SCORE = 4;
+export const RISK_RAW_SCALE_MAX = 5;
+export const RISK_DISPLAY_OFFSET = 1;
+export const RISK_DISPLAY_AXIS_MAX = RISK_RAW_SCALE_MAX - RISK_DISPLAY_OFFSET;
 
 export const RISK_REGISTRY: Record<RiskLevel, RiskRegistryEntry> = {
   low: {
@@ -109,27 +111,17 @@ export function toRiskLevel(score: number): RiskLevel {
 
 /**
  * Maps a raw risk score onto the shared chart display coordinate system.
- * The pythermalcomfort sports heat-risk model caps scores at 4.0, and that maximum score
- * should render on the High/Extreme boundary rather than within the Extreme band.
+ * The frontend displays raw scores on a 5.0 scale shifted onto a 0..4 axis.
  */
 export function toRiskDisplayScore(score: number): number | null {
   if (!Number.isFinite(score)) {
     return null;
   }
 
-  if (score <= 1) {
-    return 0;
-  }
-
-  if (score === MAX_RISK_SCORE) {
-    return MAX_RISK_SCORE - 1;
-  }
-
-  if (score > MAX_RISK_SCORE) {
-    return MAX_RISK_SCORE;
-  }
-
-  return score - 1;
+  return Math.min(
+    Math.max(score - RISK_DISPLAY_OFFSET, 0),
+    RISK_DISPLAY_AXIS_MAX,
+  );
 }
 
 /**
@@ -168,7 +160,7 @@ export function getRiskBands(): RiskBand[] {
     lower: RISK_REGISTRY[level].scoreLowerInclusive,
     upper:
       level === "extreme"
-        ? MAX_RISK_SCORE
+        ? RISK_DISPLAY_AXIS_MAX
         : RISK_REGISTRY[level].scoreUpperExclusive,
     color: RISK_REGISTRY[level].color,
   }));

--- a/frontend/src/lib/riskCharts.test.ts
+++ b/frontend/src/lib/riskCharts.test.ts
@@ -183,7 +183,7 @@ describe("buildForecastOption", () => {
     expect(rendered).not.toContain("1.5");
   });
 
-  it("renders a max score point on the high/extreme boundary", () => {
+  it("renders an extreme threshold point on the high/extreme boundary", () => {
     const option = buildForecastOption(
       [
         { time: "08:00", value: 3.5 },
@@ -234,6 +234,56 @@ describe("buildForecastOption", () => {
 
     expect(rendered).toContain("4.0");
     expect(rendered).not.toContain("3.0");
+  });
+
+  it("renders a 5.0 score point on the extreme upper boundary", () => {
+    const option = buildForecastOption(
+      [
+        { time: "08:00", value: 4.9 },
+        { time: "09:00", value: 5.0 },
+      ],
+      forecastLabels,
+      "Today",
+    );
+    const series = Array.isArray(option.series) ? option.series : [];
+    const visualSeries = series.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "name" in entry &&
+        entry.name === "Risk-visual",
+    );
+    const pointSeries = series.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "name" in entry &&
+        entry.name === "Risk-points",
+    );
+    const tooltip =
+      option.tooltip && !Array.isArray(option.tooltip) ? option.tooltip : null;
+    const visualData = (visualSeries as { data?: Array<[number, number]> })
+      .data;
+    const pointData = (pointSeries as { data?: Array<[number, number]> }).data;
+
+    expect(visualData?.[0]?.[0]).toBe(480);
+    expect(visualData?.[0]?.[1]).toBeCloseTo(3.9);
+    expect(visualData?.[1]).toEqual([540, 4]);
+    expect(pointData?.[0]?.[0]).toBe(480);
+    expect(pointData?.[0]?.[1]).toBeCloseTo(3.9);
+    expect(pointData?.[1]).toEqual([540, 4]);
+
+    const formatter = tooltip?.formatter as (params: unknown) => string;
+    const rendered = formatter([
+      {
+        axisValue: 480,
+        name: "08:00",
+        value: [480, 3.9000000000000004],
+      },
+    ]);
+
+    expect(rendered).toContain("4.9");
+    expect(rendered).not.toContain("3.9");
   });
 
   it("keeps mobile x-axis labels on a regular cadence", () => {

--- a/frontend/src/lib/riskCharts.ts
+++ b/frontend/src/lib/riskCharts.ts
@@ -9,7 +9,7 @@ import { USYD_ORANGE_HEX } from "@/config/uiColors";
 import {
   getRiskBands,
   getRiskColor,
-  MAX_RISK_SCORE,
+  RISK_DISPLAY_AXIS_MAX,
   toRiskDisplayScore,
 } from "@/domain/riskRegistry";
 
@@ -156,7 +156,7 @@ function toForecastChartPoints(
 
   const thresholds = getRiskBands()
     .map((band) => band.upper)
-    .filter((threshold) => threshold > 0 && threshold < MAX_RISK_SCORE);
+    .filter((threshold) => threshold > 0 && threshold < RISK_DISPLAY_AXIS_MAX);
   const expandedPoints: ForecastChartPoint[] = [points[0]];
 
   for (let index = 1; index < points.length; index += 1) {
@@ -471,7 +471,7 @@ function createForecastYAxis(
     {
       type: "value" as const,
       min: 0,
-      max: MAX_RISK_SCORE,
+      max: RISK_DISPLAY_AXIS_MAX,
       interval: 1,
       axisPointer: {
         show: false,

--- a/frontend/src/lib/riskGauge.test.ts
+++ b/frontend/src/lib/riskGauge.test.ts
@@ -42,6 +42,8 @@ describe("riskGauge helpers", () => {
     expect(getRiskGaugePointerAngle(2.5)).toBe(112.5);
     expect(getRiskGaugePointerAngle(3.5)).toBe(67.5);
     expect(getRiskGaugePointerAngle(4)).toBe(45);
+    expect(getRiskGaugePointerAngle(4.9)).toBeCloseTo(4.5);
+    expect(getRiskGaugePointerAngle(5)).toBe(0);
   });
 
   it("remaps raw scores into the display range and falls back to N/A when unavailable", () => {
@@ -49,10 +51,12 @@ describe("riskGauge helpers", () => {
     expect(normalizeRiskGaugeScore(0.8)).toBe(0);
     expect(normalizeRiskGaugeScore(1.5)).toBe(0.5);
     expect(normalizeRiskGaugeScore(4)).toBe(3);
+    expect(normalizeRiskGaugeScore(4.9)).toBeCloseTo(3.9);
+    expect(normalizeRiskGaugeScore(5)).toBe(4);
     expect(normalizeRiskGaugeScore(6)).toBe(4);
     expect(getRiskGaugePointerAngle(Number.NaN)).toBeNull();
     expect(formatRiskGaugeValue(Number.NaN, "N/A")).toBe("N/A");
-    expect(formatRiskGaugeValue(4, "N/A")).toBe("4.0");
+    expect(formatRiskGaugeValue(4.9, "N/A")).toBe("4.9");
   });
 
   it("resolves default and clamped gauge widths from a single helper", () => {

--- a/frontend/src/lib/riskGauge.ts
+++ b/frontend/src/lib/riskGauge.ts
@@ -5,12 +5,12 @@ import { getReadableTextColor } from "@/lib/colorContrast";
 import {
   getRiskBands,
   getRiskColor,
-  MAX_RISK_SCORE,
+  RISK_DISPLAY_AXIS_MAX,
   toRiskDisplayScore,
 } from "@/domain/riskRegistry";
 
 export const RISK_GAUGE_MIN_SCORE = 0;
-export const RISK_GAUGE_MAX_SCORE = MAX_RISK_SCORE;
+export const RISK_GAUGE_MAX_SCORE = RISK_DISPLAY_AXIS_MAX;
 export const RISK_GAUGE_MIN_WIDTH = 200;
 export const RISK_GAUGE_MAX_WIDTH = 400;
 const RISK_GAUGE_TOTAL_ANGLE = 180;


### PR DESCRIPTION
## Summary

- Upgrade backend `pythermalcomfort` to `4.0.2`.
- Update frontend risk display mapping for the 5.0 raw scale.
- Keep `risk=4.0` on the High/Extreme boundary and `risk=5.0` at the Extreme upper bound.
- Add coverage for `4.9` and `5.0` risk score handling.

## Changes

- Refresh backend `uv.lock` for `pythermalcomfort==4.0.2`.
- Keep backend API response shape unchanged and continue passing through raw `risk_level_interpolated`.
- Replace the old frontend max-risk display special case with `clamp(rawRisk - 1, 0, 4)`.
- Update gauge and forecast chart tests for the new display scale.

## Validation

- `pnpm format`
- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm build`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest`
- Backend uvicorn startup sanity check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended risk score range support: heat risk now properly handles scores up to 5.0 with updated visual scaling.

* **Bug Fixes**
  * Improved risk display calculations with offset-based scaling for more accurate visual representation in charts and gauges.

* **Tests**
  * Expanded test coverage for heat risk and risk scoring across the full supported range.

* **Chores**
  * Updated pythermalcomfort dependency to version 4.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->