### PR TITLE
[Feature] Multi-City Dashboard View dy

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -43,6 +43,7 @@
 
 ## API Contract Rules
 - Preserve route: `POST /home/risk`.
+- Add route: `POST /home/risk/batch` for multi-city dashboard summaries.
 - Request requires `latitude` and `longitude`.
 - `sport` must be official pythermalcomfort `Sports` enum name (e.g. `SOCCER`).
 - Response shape:

--- a/backend/README.md
+++ b/backend/README.md
@@ -177,6 +177,86 @@ Example response:
 }
 ```
 
+### `POST /home/risk/batch`
+
+Dashboard summary endpoint for up to **6** locations in one request.
+
+Request body:
+
+- `sport: string`
+  Same rules as `POST /home/risk`.
+- `profile: string`
+  Same rules as `POST /home/risk`.
+- `locations: array`
+  Required. Length `1` to `6`. Each item requires:
+  - `latitude: number` in `[-90, 90]`
+  - `longitude: number` in `[-180, 180]`
+
+Example request:
+
+```json
+{
+  "sport": "SOCCER",
+  "profile": "ADULT",
+  "locations": [
+    { "latitude": -33.847, "longitude": 151.067 },
+    { "latitude": -37.813, "longitude": 144.963 }
+  ]
+}
+```
+
+Response contract:
+
+- Returns `200` for valid batch requests, even when individual locations fail.
+- Weather is fetched from Open-Meteo in one multi-location request per chunk (up to 10 coordinates per upstream call).
+- Successful location summaries are cached in memory with the same TTL as `POST /home/risk`. Errors are not cached. This cache is separate from the seven-day home forecast cache.
+- Each `locations[]` entry includes:
+  - `status`: `"ok"` or `"error"`
+  - `current_risk_level_interpolated`: same semantics as `forecast[0]` on `/home/risk`
+  - `today_max_risk_level_interpolated`: max score for the current local calendar day
+  - `timezone`, `current_time_local`, `error_code`, and `detail`
+
+Example response:
+
+```json
+{
+  "request": {
+    "sport": "SOCCER",
+    "profile": "ADULT"
+  },
+  "locations": [
+    {
+      "latitude": -33.847,
+      "longitude": 151.067,
+      "timezone": "Australia/Sydney",
+      "status": "ok",
+      "current_risk_level_interpolated": 1.94,
+      "today_max_risk_level_interpolated": 2.14,
+      "current_time_local": "2026-03-09T11:00:00+11:00",
+      "error_code": null,
+      "detail": null
+    },
+    {
+      "latitude": -37.813,
+      "longitude": 144.963,
+      "timezone": "Australia/Melbourne",
+      "status": "error",
+      "current_risk_level_interpolated": null,
+      "today_max_risk_level_interpolated": null,
+      "current_time_local": null,
+      "error_code": "weather_provider_unavailable",
+      "detail": "Weather provider unavailable"
+    }
+  ]
+}
+```
+
+Per-location error codes:
+
+- `weather_provider_unavailable`
+- `unknown_inputs`
+- `risk_calculation_failed`
+
 ## Risk Flow
 
 1. Fetch Open-Meteo hourly weather with:
@@ -213,6 +293,7 @@ Example response:
 
 - The risk service keeps an in-memory TTL cache keyed by:
   `sport + profile + latitude + longitude`
+- Dashboard batch summaries use a separate in-memory cache with the same TTL.
 - Requests from different users will reuse cached results only when they hit the
   same backend process.
 - The cache is not shared across multiple server instances.

--- a/backend/src/sma_extreme_heat_backend/api/routes.py
+++ b/backend/src/sma_extreme_heat_backend/api/routes.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
+from sma_extreme_heat_backend.schemas.batch import BatchRiskRequest, BatchRiskResponse
 from sma_extreme_heat_backend.schemas.home import RiskRequest, RiskResponse
 from sma_extreme_heat_backend.services.risk_service import RiskService, get_risk_service
 
@@ -30,3 +31,13 @@ async def calculate_home_risk(
     """Calculate the forecast-centric home heat-risk response."""
 
     return await risk_service.calculate_home_risk(payload)
+
+
+@router.post("/home/risk/batch", response_model=BatchRiskResponse, tags=["home"])
+async def calculate_home_risk_batch(
+    payload: BatchRiskRequest,
+    risk_service: Annotated[RiskService, Depends(get_risk_service)],
+) -> BatchRiskResponse:
+    """Calculate dashboard heat-risk summaries for multiple locations."""
+
+    return await risk_service.calculate_home_risk_batch(payload)

--- a/backend/src/sma_extreme_heat_backend/clients/open_meteo.py
+++ b/backend/src/sma_extreme_heat_backend/clients/open_meteo.py
@@ -50,6 +50,47 @@ class WeatherForecast:
     points: list[HourlyWeatherPoint]
 
 
+@dataclass(frozen=True)
+class WeatherLocationRequest:
+    """One coordinate and timezone pair for a multi-location Open-Meteo request."""
+
+    latitude: float
+    longitude: float
+    timezone_name: str
+
+
+@dataclass(frozen=True)
+class LocationWeatherFetchResult:
+    """Per-location outcome from a batched Open-Meteo weather fetch."""
+
+    forecast: WeatherForecast | None = None
+    error: WeatherProviderError | None = None
+    unexpected_error: Exception | None = None
+
+    @classmethod
+    def success(cls, forecast: WeatherForecast) -> LocationWeatherFetchResult:
+        """Wrap a parsed forecast for one location."""
+
+        return cls(forecast=forecast)
+
+    @classmethod
+    def failure(cls, error: WeatherProviderError) -> LocationWeatherFetchResult:
+        """Wrap a provider failure for one location."""
+
+        return cls(error=error)
+
+    @classmethod
+    def unexpected_failure(cls, error: Exception) -> LocationWeatherFetchResult:
+        """Wrap an unexpected failure for one location."""
+
+        return cls(unexpected_error=error)
+
+
+_BATCH_LOCATION_CHUNK_SIZE = 10
+_DEFAULT_FORECAST_WINDOW_DAYS = 7
+_BATCH_FORECAST_WINDOW_DAYS = 2
+
+
 def _to_float_or_none(value: Any) -> float | None:
     """Convert provider values to floats while treating invalid values as missing."""
 
@@ -174,15 +215,16 @@ def _select_hourly_points(
     payload: dict[str, Any],
     *,
     requested_timezone_name: str,
+    forecast_window_days: int = _DEFAULT_FORECAST_WINDOW_DAYS,
 ) -> list[HourlyWeatherPoint]:
-    """Keep only the current-to-7-day forecast window and normalize each row."""
+    """Keep only the current forecast window and normalize each row."""
 
     timestamps, series_data = _extract_hourly_series(
         payload,
         requested_timezone_name=requested_timezone_name,
     )
     threshold = datetime.now(tz=UTC) - timedelta(hours=1)
-    forecast_window_end = threshold + timedelta(days=7)
+    forecast_window_end = threshold + timedelta(days=forecast_window_days)
     candidate_rows = [
         (idx, timestamp)
         for idx, timestamp in sorted(enumerate(timestamps), key=lambda item: item[1])
@@ -201,6 +243,37 @@ def _select_hourly_points(
         )
         for idx, timestamp in candidate_rows
     ]
+
+
+def _normalize_multi_location_payload(payload: Any) -> list[dict[str, Any]]:
+    """Normalize single- or multi-location Open-Meteo JSON into a list of payloads."""
+
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        if not payload:
+            raise WeatherProviderError("Weather provider response was empty")
+        if not all(isinstance(item, dict) for item in payload):
+            raise WeatherProviderError("Weather provider response contained invalid locations")
+        return payload
+    raise WeatherProviderError("Weather provider response had an unexpected shape")
+
+
+def _parse_location_weather_payload(
+    payload: dict[str, Any],
+    *,
+    requested_timezone_name: str,
+    forecast_window_days: int,
+) -> WeatherForecast:
+    """Parse one Open-Meteo location payload into a normalized forecast."""
+
+    _validate_hourly_units(payload)
+    points = _select_hourly_points(
+        payload,
+        requested_timezone_name=requested_timezone_name,
+        forecast_window_days=forecast_window_days,
+    )
+    return WeatherForecast(points=points)
 
 
 class OpenMeteoClient:
@@ -241,9 +314,70 @@ class OpenMeteoClient:
 
         payload = await self._fetch_weather_payload(params=params)
 
-        _validate_hourly_units(payload)
-        points = _select_hourly_points(payload, requested_timezone_name=timezone_name)
-        return WeatherForecast(points=points)
+        return _parse_location_weather_payload(
+            payload,
+            requested_timezone_name=timezone_name,
+            forecast_window_days=_DEFAULT_FORECAST_WINDOW_DAYS,
+        )
+
+    async def fetch_weather_forecast_batch(
+        self,
+        *,
+        locations: list[WeatherLocationRequest],
+    ) -> list[LocationWeatherFetchResult]:
+        """Fetch hourly weather for multiple locations using comma-separated coordinates."""
+
+        if not locations:
+            return []
+
+        results: list[LocationWeatherFetchResult] = []
+        for chunk_start in range(0, len(locations), _BATCH_LOCATION_CHUNK_SIZE):
+            chunk = locations[chunk_start : chunk_start + _BATCH_LOCATION_CHUNK_SIZE]
+            results.extend(await self._fetch_weather_forecast_chunk(locations=chunk))
+        return results
+
+    async def _fetch_weather_forecast_chunk(
+        self,
+        *,
+        locations: list[WeatherLocationRequest],
+    ) -> list[LocationWeatherFetchResult]:
+        """Fetch one multi-location chunk and parse each location independently."""
+
+        params = {
+            "latitude": ",".join(str(location.latitude) for location in locations),
+            "longitude": ",".join(str(location.longitude) for location in locations),
+            "hourly": ",".join(_HOURLY_FIELDS),
+            "wind_speed_unit": "ms",
+            "timezone": ",".join(location.timezone_name for location in locations),
+            "forecast_days": _BATCH_FORECAST_WINDOW_DAYS,
+        }
+
+        try:
+            payloads = _normalize_multi_location_payload(
+                await self._fetch_weather_payload(params=params)
+            )
+        except WeatherProviderError as exc:
+            return [LocationWeatherFetchResult.failure(exc) for _ in locations]
+
+        if len(payloads) != len(locations):
+            error = WeatherProviderError(
+                "Weather provider response location count did not match the request"
+            )
+            return [LocationWeatherFetchResult.failure(error) for _ in locations]
+
+        results: list[LocationWeatherFetchResult] = []
+        for location, payload in zip(locations, payloads, strict=True):
+            try:
+                forecast = _parse_location_weather_payload(
+                    payload,
+                    requested_timezone_name=location.timezone_name,
+                    forecast_window_days=_BATCH_FORECAST_WINDOW_DAYS,
+                )
+            except WeatherProviderError as exc:
+                results.append(LocationWeatherFetchResult.failure(exc))
+                continue
+            results.append(LocationWeatherFetchResult.success(forecast))
+        return results
 
     def _build_async_client(self) -> httpx.AsyncClient:
         """Build an owned HTTPX client with the configured Open-Meteo settings."""

--- a/backend/src/sma_extreme_heat_backend/schemas/batch.py
+++ b/backend/src/sma_extreme_heat_backend/schemas/batch.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import ClassVar
+
+from pydantic import BaseModel, Field, FiniteFloat, field_validator
+
+from sma_extreme_heat_backend.schemas.home import ALLOWED_SPORTS, RiskProfile
+
+BATCH_RISK_LOCATION_MAX = 6
+
+
+class BatchRiskLocationRequest(BaseModel):
+    """One coordinate pair in a batch heat-risk request."""
+
+    latitude: FiniteFloat = Field(ge=-90, le=90)
+    longitude: FiniteFloat = Field(ge=-180, le=180)
+
+
+class BatchRiskRequest(BaseModel):
+    """Validated request payload for `/home/risk/batch`."""
+
+    sport: str = Field(min_length=1)
+    profile: RiskProfile
+    locations: list[BatchRiskLocationRequest] = Field(
+        min_length=1,
+        max_length=BATCH_RISK_LOCATION_MAX,
+    )
+
+    _allowed_sports: ClassVar[set[str]] = set(ALLOWED_SPORTS)
+
+    @field_validator("sport")
+    @classmethod
+    def validate_sport(cls, value: str) -> str:
+        """Require the exact pythermalcomfort `Sports` enum member name."""
+
+        if value not in cls._allowed_sports:
+            raise ValueError("sport must use official pythermalcomfort Sports enum name")
+        return value
+
+
+class BatchRiskRequestSummary(BaseModel):
+    """Shared request context returned with a batch response."""
+
+    sport: str = Field(min_length=1)
+    profile: RiskProfile
+
+
+class BatchRiskLocationStatus(StrEnum):
+    """Per-location outcome for a batch heat-risk response."""
+
+    OK = "ok"
+    ERROR = "error"
+
+
+class BatchRiskLocationResult(BaseModel):
+    """Summary heat-risk data for one batch location."""
+
+    latitude: FiniteFloat = Field(ge=-90, le=90)
+    longitude: FiniteFloat = Field(ge=-180, le=180)
+    timezone: str | None = None
+    status: BatchRiskLocationStatus
+    current_risk_level_interpolated: FiniteFloat | None = None
+    today_max_risk_level_interpolated: FiniteFloat | None = None
+    current_time_local: datetime | None = None
+    error_code: str | None = None
+    detail: str | None = None
+
+
+class BatchRiskResponse(BaseModel):
+    """Batch summary response for the multi-city dashboard."""
+
+    request: BatchRiskRequestSummary
+    locations: list[BatchRiskLocationResult]

--- a/backend/src/sma_extreme_heat_backend/services/batch_summary.py
+++ b/backend/src/sma_extreme_heat_backend/services/batch_summary.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sma_extreme_heat_backend.schemas.home import ForecastPoint
+
+
+def get_today_max_risk_level_interpolated(forecast: list[ForecastPoint]) -> float:
+    """Return the max interpolated risk score for the current local calendar day."""
+
+    if not forecast:
+        raise ValueError("Forecast must contain at least one point")
+
+    today = forecast[0].time_local.date()
+    today_max = forecast[0].heat_risk.risk_level_interpolated
+
+    for point in forecast[1:]:
+        if point.time_local.date() != today:
+            continue
+        today_max = max(today_max, point.heat_risk.risk_level_interpolated)
+
+    return float(today_max)

--- a/backend/src/sma_extreme_heat_backend/services/risk_service.py
+++ b/backend/src/sma_extreme_heat_backend/services/risk_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -13,11 +14,25 @@ from sma_extreme_heat_backend.calculators.sports_heat_stress import (
     SportsHeatStressCalculator,
     SportsHeatStressInput,
 )
-from sma_extreme_heat_backend.clients.open_meteo import OpenMeteoClient
+from sma_extreme_heat_backend.clients.open_meteo import (
+    LocationWeatherFetchResult,
+    OpenMeteoClient,
+    WeatherLocationRequest,
+)
 from sma_extreme_heat_backend.core.config import get_settings
 from sma_extreme_heat_backend.core.errors import (
+    AppError,
     ModelInputUnavailableError,
+    RiskCalculationError,
     WeatherProviderError,
+)
+from sma_extreme_heat_backend.schemas.batch import (
+    BatchRiskLocationRequest,
+    BatchRiskLocationResult,
+    BatchRiskLocationStatus,
+    BatchRiskRequest,
+    BatchRiskRequestSummary,
+    BatchRiskResponse,
 )
 from sma_extreme_heat_backend.schemas.home import (
     ForecastHeatRisk,
@@ -25,8 +40,12 @@ from sma_extreme_heat_backend.schemas.home import (
     ForecastPoint,
     LocationSummary,
     RequestSummary,
+    RiskProfile,
     RiskRequest,
     RiskResponse,
+)
+from sma_extreme_heat_backend.services.batch_summary import (
+    get_today_max_risk_level_interpolated,
 )
 from sma_extreme_heat_backend.services.mrt import (
     build_mrt_dataframe,
@@ -35,10 +54,10 @@ from sma_extreme_heat_backend.services.mrt import (
 
 
 @dataclass
-class CacheEntry:
-    """In-memory TTL cache entry for a computed risk response."""
+class CacheEntry[T]:
+    """In-memory TTL cache entry for a computed risk result."""
 
-    value: RiskResponse
+    value: T
     expires_at: float
 
 
@@ -53,6 +72,7 @@ class WindSpeedRefactorConfig:
 
 
 WIND_SPEED_REFACTOR_CONFIG = WindSpeedRefactorConfig()
+LOGGER = logging.getLogger(__name__)
 
 _PUBLIC_INPUT_FIELD_BY_COLUMN: dict[str, str] = {
     "tdb": "air_temperature_c",
@@ -78,7 +98,8 @@ class RiskService:
         self.weather_client = weather_client
         self.calculator = calculator
         self.ttl_seconds = ttl_seconds
-        self._cache: dict[str, CacheEntry] = {}
+        self._cache: dict[str, CacheEntry[RiskResponse]] = {}
+        self._batch_cache: dict[str, CacheEntry[BatchRiskLocationResult]] = {}
 
     async def calculate_home_risk(self, payload: RiskRequest) -> RiskResponse:
         """Calculate and cache a forecast-centric heat-risk response."""
@@ -124,16 +145,249 @@ class RiskService:
         self._cache[key] = CacheEntry(value=response, expires_at=now + self.ttl_seconds)
         return response
 
+    async def calculate_home_risk_batch(
+        self,
+        payload: BatchRiskRequest,
+    ) -> BatchRiskResponse:
+        """Calculate dashboard summaries for multiple locations in one request."""
+
+        now = time.monotonic()
+        results: list[BatchRiskLocationResult | None] = [None] * len(payload.locations)
+        miss_indices: list[int] = []
+
+        for index, location in enumerate(payload.locations):
+            cached = self._batch_cache.get(
+                self._batch_cache_key(
+                    sport=payload.sport,
+                    profile=payload.profile,
+                    latitude=location.latitude,
+                    longitude=location.longitude,
+                )
+            )
+            if cached and cached.expires_at > now:
+                results[index] = cached.value
+                continue
+            miss_indices.append(index)
+
+        if miss_indices:
+            await self._fill_batch_cache_misses(
+                payload=payload,
+                miss_indices=miss_indices,
+                results=results,
+            )
+
+        populated_results: list[BatchRiskLocationResult] = []
+        for result in results:
+            if result is None:
+                raise RuntimeError("Batch location result was not populated")
+            populated_results.append(result)
+
+        return BatchRiskResponse(
+            request=BatchRiskRequestSummary(
+                sport=payload.sport,
+                profile=payload.profile,
+            ),
+            locations=populated_results,
+        )
+
     async def aclose(self) -> None:
         """Close the owned weather client resources."""
 
         await self.weather_client.aclose()
+
+    async def _fill_batch_cache_misses(
+        self,
+        *,
+        payload: BatchRiskRequest,
+        miss_indices: list[int],
+        results: list[BatchRiskLocationResult | None],
+    ) -> None:
+        """Fetch and summarize uncached batch locations, storing successful summaries."""
+
+        miss_locations = [payload.locations[index] for index in miss_indices]
+        location_contexts = self._resolve_batch_location_contexts(miss_locations)
+        weather_results = await self._fetch_batch_weather(location_contexts)
+        now = time.monotonic()
+
+        for index, (location, timezone_name, timezone_error), weather_result in zip(
+            miss_indices,
+            location_contexts,
+            weather_results,
+            strict=True,
+        ):
+            summary = self._summarize_location(
+                sport=payload.sport,
+                location=location,
+                timezone_name=timezone_name,
+                timezone_error=timezone_error,
+                weather_result=weather_result,
+            )
+            if summary.status == BatchRiskLocationStatus.OK:
+                self._batch_cache[
+                    self._batch_cache_key(
+                        sport=payload.sport,
+                        profile=payload.profile,
+                        latitude=location.latitude,
+                        longitude=location.longitude,
+                    )
+                ] = CacheEntry(value=summary, expires_at=now + self.ttl_seconds)
+            results[index] = summary
 
     @staticmethod
     def _cache_key(payload: RiskRequest) -> str:
         """Build a stable cache key for the current request contract."""
 
         return f"{payload.sport}|{payload.profile}|{payload.latitude:.6f}|{payload.longitude:.6f}"
+
+    @staticmethod
+    def _batch_cache_key(
+        *,
+        sport: str,
+        profile: RiskProfile,
+        latitude: float,
+        longitude: float,
+    ) -> str:
+        """Build a cache key for a successful dashboard location summary.
+
+        Coordinates use `repr` so values that round identically at six decimals
+        still produce independent cache entries.
+        """
+
+        return f"batch|{sport}|{profile}|{latitude!r}|{longitude!r}"
+
+    @staticmethod
+    def _resolve_batch_location_contexts(
+        locations: list[BatchRiskLocationRequest],
+    ) -> list[tuple[BatchRiskLocationRequest, str | None, AppError | None]]:
+        """Resolve timezone metadata for each batch location."""
+
+        contexts: list[tuple[BatchRiskLocationRequest, str | None, AppError | None]] = []
+        for location in locations:
+            try:
+                timezone_name = resolve_timezone_name(
+                    latitude=location.latitude,
+                    longitude=location.longitude,
+                )
+            except AppError as exc:
+                contexts.append((location, None, exc))
+                continue
+            contexts.append((location, timezone_name, None))
+        return contexts
+
+    async def _fetch_batch_weather(
+        self,
+        location_contexts: list[tuple[BatchRiskLocationRequest, str | None, AppError | None]],
+    ) -> list[LocationWeatherFetchResult | None]:
+        """Fetch weather for all resolvable batch locations in one provider call."""
+
+        fetch_requests: list[WeatherLocationRequest] = []
+        fetchable_indices: list[int] = []
+        for index, (location, timezone_name, timezone_error) in enumerate(location_contexts):
+            if timezone_error is not None or timezone_name is None:
+                continue
+            fetchable_indices.append(index)
+            fetch_requests.append(
+                WeatherLocationRequest(
+                    latitude=location.latitude,
+                    longitude=location.longitude,
+                    timezone_name=timezone_name,
+                )
+            )
+
+        weather_results: list[LocationWeatherFetchResult | None] = [None] * len(location_contexts)
+        if not fetch_requests:
+            return weather_results
+
+        try:
+            fetched = await self.weather_client.fetch_weather_forecast_batch(
+                locations=fetch_requests,
+            )
+        except Exception as exc:
+            LOGGER.exception("Unexpected batch weather fetch failure")
+            failure = LocationWeatherFetchResult.unexpected_failure(exc)
+            for index in fetchable_indices:
+                weather_results[index] = failure
+            return weather_results
+
+        for index, result in zip(fetchable_indices, fetched, strict=True):
+            weather_results[index] = result
+        return weather_results
+
+    def _summarize_location(
+        self,
+        *,
+        sport: str,
+        location: BatchRiskLocationRequest,
+        timezone_name: str | None = None,
+        timezone_error: AppError | None = None,
+        weather_result: LocationWeatherFetchResult | None = None,
+    ) -> BatchRiskLocationResult:
+        """Summarize one location, mapping failures to per-location error results."""
+
+        try:
+            if timezone_error is not None:
+                raise timezone_error
+            if timezone_name is None:
+                raise WeatherProviderError("Could not resolve location timezone from coordinates")
+            if weather_result is None:
+                raise WeatherProviderError()
+            if weather_result.unexpected_error is not None:
+                raise weather_result.unexpected_error
+            if weather_result.error is not None:
+                raise weather_result.error
+            if weather_result.forecast is None:
+                raise WeatherProviderError()
+
+            mrt_df = build_mrt_dataframe(
+                points=weather_result.forecast.points,
+                latitude=location.latitude,
+                longitude=location.longitude,
+                timezone_name=timezone_name,
+            )
+            forecast = self._build_forecast(forecast_mrt_df=mrt_df, sport=sport)
+            current_point = forecast[0]
+            return BatchRiskLocationResult(
+                latitude=location.latitude,
+                longitude=location.longitude,
+                timezone=timezone_name,
+                status=BatchRiskLocationStatus.OK,
+                current_risk_level_interpolated=current_point.heat_risk.risk_level_interpolated,
+                today_max_risk_level_interpolated=get_today_max_risk_level_interpolated(forecast),
+                current_time_local=current_point.time_local,
+                error_code=None,
+                detail=None,
+            )
+        except AppError as exc:
+            error_code, detail = _map_batch_location_error(exc)
+            return BatchRiskLocationResult(
+                latitude=location.latitude,
+                longitude=location.longitude,
+                timezone=timezone_name,
+                status=BatchRiskLocationStatus.ERROR,
+                current_risk_level_interpolated=None,
+                today_max_risk_level_interpolated=None,
+                current_time_local=None,
+                error_code=error_code,
+                detail=detail,
+            )
+        except Exception:
+            LOGGER.exception(
+                "Unexpected batch location failure latitude=%s longitude=%s sport=%s",
+                location.latitude,
+                location.longitude,
+                sport,
+            )
+            return BatchRiskLocationResult(
+                latitude=location.latitude,
+                longitude=location.longitude,
+                timezone=timezone_name,
+                status=BatchRiskLocationStatus.ERROR,
+                current_risk_level_interpolated=None,
+                today_max_risk_level_interpolated=None,
+                current_time_local=None,
+                error_code="risk_calculation_failed",
+                detail="Risk calculation failed",
+            )
 
     def _build_forecast(
         self,
@@ -314,3 +568,30 @@ def _to_optional_float(value: float | None) -> float | None:
     if value is None or pd.isna(value):
         return None
     return float(value)
+
+
+def _map_batch_location_error(exc: AppError) -> tuple[str, str]:
+    """Map a single-location failure into stable batch error fields."""
+
+    if isinstance(exc, WeatherProviderError):
+        return "weather_provider_unavailable", _app_error_detail_message(exc)
+    if isinstance(exc, ModelInputUnavailableError):
+        return "unknown_inputs", _app_error_detail_message(exc)
+    if isinstance(exc, RiskCalculationError):
+        return "risk_calculation_failed", _app_error_detail_message(exc)
+    if exc.error_code is not None:
+        return exc.error_code, _app_error_detail_message(exc)
+    return "risk_calculation_failed", _app_error_detail_message(exc)
+
+
+def _app_error_detail_message(exc: AppError) -> str:
+    """Serialize an application error detail into a response-safe string."""
+
+    detail = exc.detail
+    if isinstance(detail, str):
+        return detail
+    if isinstance(detail, dict):
+        message = detail.get("message")
+        if isinstance(message, str) and message.strip():
+            return message
+    return str(detail)

--- a/backend/tests/api/test_home_risk_batch.py
+++ b/backend/tests/api/test_home_risk_batch.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sma_extreme_heat_backend.api.routes import get_risk_service
+from sma_extreme_heat_backend.core.errors import ModelInputUnavailableError, WeatherProviderError
+from sma_extreme_heat_backend.main import create_app
+from sma_extreme_heat_backend.schemas.batch import (
+    BATCH_RISK_LOCATION_MAX,
+    BatchRiskLocationResult,
+    BatchRiskLocationStatus,
+    BatchRiskRequest,
+    BatchRiskRequestSummary,
+    BatchRiskResponse,
+)
+from sma_extreme_heat_backend.schemas.home import (
+    ForecastHeatRisk,
+    ForecastInputs,
+    ForecastPoint,
+    LocationSummary,
+    RequestSummary,
+    RiskRequest,
+    RiskResponse,
+)
+from sma_extreme_heat_backend.services.batch_summary import (
+    get_today_max_risk_level_interpolated,
+)
+
+VALID_PROFILES = ("ADULT", "UNDER_10", "AGE_10_13", "AGE_14_17")
+VALID_SPORTS = ("SOCCER", "CROQUET")
+SYDNEY_LAT = -33.847
+SYDNEY_LNG = 151.067
+MELBOURNE_LAT = -37.813
+MELBOURNE_LNG = 144.963
+
+
+def _successful_risk_response(*, latitude: float, longitude: float) -> RiskResponse:
+    return RiskResponse(
+        request=RequestSummary(
+            sport="SOCCER",
+            profile="ADULT",
+            location=LocationSummary(
+                latitude=latitude,
+                longitude=longitude,
+                timezone="Australia/Sydney"
+                if abs(longitude - SYDNEY_LNG) < 0.001
+                else "Australia/Melbourne",
+            ),
+        ),
+        forecast=[
+            ForecastPoint(
+                time_utc="2026-03-09T00:00:00Z",
+                time_local="2026-03-09T11:00:00+11:00",
+                inputs=ForecastInputs(
+                    air_temperature_c=31.0,
+                    mean_radiant_temperature_c=37.25,
+                    relative_humidity_pct=62.0,
+                    wind_speed_10m_ms=1.5,
+                    direct_normal_irradiance_wm2=700.0,
+                ),
+                heat_risk=ForecastHeatRisk(
+                    risk_level_interpolated=1.2,
+                    t_medium=34.5,
+                    t_high=37.1,
+                    t_extreme=39.2,
+                    recommendation="Increase hydration & modify clothing",
+                ),
+            ),
+            ForecastPoint(
+                time_utc="2026-03-09T01:00:00Z",
+                time_local="2026-03-09T12:00:00+11:00",
+                inputs=ForecastInputs(
+                    air_temperature_c=32.0,
+                    mean_radiant_temperature_c=38.1,
+                    relative_humidity_pct=61.0,
+                    wind_speed_10m_ms=1.6,
+                    direct_normal_irradiance_wm2=740.0,
+                ),
+                heat_risk=ForecastHeatRisk(
+                    risk_level_interpolated=1.6,
+                    t_medium=34.5,
+                    t_high=37.1,
+                    t_extreme=39.2,
+                    recommendation="Increase hydration & modify clothing",
+                ),
+            ),
+        ],
+    )
+
+
+class BatchRiskServiceStub:
+    """Route test double that simulates mixed batch outcomes."""
+
+    async def calculate_home_risk(self, payload: RiskRequest) -> RiskResponse:
+        if abs(payload.longitude - MELBOURNE_LNG) < 0.001:
+            raise WeatherProviderError()
+        return _successful_risk_response(
+            latitude=payload.latitude,
+            longitude=payload.longitude,
+        )
+
+    async def calculate_home_risk_batch(
+        self,
+        payload: BatchRiskRequest,
+    ) -> BatchRiskResponse:
+        locations: list[BatchRiskLocationResult] = []
+        for location in payload.locations:
+            try:
+                response = await self.calculate_home_risk(
+                    RiskRequest(
+                        sport=payload.sport,
+                        latitude=location.latitude,
+                        longitude=location.longitude,
+                        profile=payload.profile,
+                    )
+                )
+            except WeatherProviderError:
+                locations.append(
+                    BatchRiskLocationResult(
+                        latitude=location.latitude,
+                        longitude=location.longitude,
+                        timezone="Australia/Melbourne",
+                        status=BatchRiskLocationStatus.ERROR,
+                        error_code="weather_provider_unavailable",
+                        detail="Weather provider unavailable",
+                    )
+                )
+                continue
+            except ModelInputUnavailableError as exc:
+                locations.append(
+                    BatchRiskLocationResult(
+                        latitude=location.latitude,
+                        longitude=location.longitude,
+                        timezone="Australia/Sydney",
+                        status=BatchRiskLocationStatus.ERROR,
+                        error_code="unknown_inputs",
+                        detail=str(exc.detail["message"]),
+                    )
+                )
+                continue
+
+            current_point = response.forecast[0]
+            locations.append(
+                BatchRiskLocationResult(
+                    latitude=location.latitude,
+                    longitude=location.longitude,
+                    timezone=response.request.location.timezone,
+                    status=BatchRiskLocationStatus.OK,
+                    current_risk_level_interpolated=current_point.heat_risk.risk_level_interpolated,
+                    today_max_risk_level_interpolated=get_today_max_risk_level_interpolated(
+                        response.forecast
+                    ),
+                    current_time_local=current_point.time_local,
+                )
+            )
+
+        return BatchRiskResponse(
+            request=BatchRiskRequestSummary(
+                sport=payload.sport,
+                profile=payload.profile,
+            ),
+            locations=locations,
+        )
+
+
+@pytest.mark.parametrize("sport", VALID_SPORTS)
+@pytest.mark.parametrize("profile", VALID_PROFILES)
+def test_post_home_risk_batch_success_returns_summary_contract(
+    profile: str,
+    sport: str,
+) -> None:
+    """The batch route should serialize the dashboard summary contract."""
+
+    app = create_app()
+    app.dependency_overrides[get_risk_service] = lambda: BatchRiskServiceStub()
+
+    payload = {
+        "sport": sport,
+        "profile": profile,
+        "locations": [
+            {"latitude": SYDNEY_LAT, "longitude": SYDNEY_LNG},
+        ],
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/home/risk/batch", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "request": {
+            "sport": sport,
+            "profile": profile,
+        },
+        "locations": [
+            {
+                "latitude": SYDNEY_LAT,
+                "longitude": SYDNEY_LNG,
+                "timezone": "Australia/Sydney",
+                "status": "ok",
+                "current_risk_level_interpolated": 1.2,
+                "today_max_risk_level_interpolated": 1.6,
+                "current_time_local": "2026-03-09T11:00:00+11:00",
+                "error_code": None,
+                "detail": None,
+            }
+        ],
+    }
+
+
+def test_post_home_risk_batch_partial_failure_returns_200() -> None:
+    """A valid batch request should return 200 even when one location fails."""
+
+    app = create_app()
+    app.dependency_overrides[get_risk_service] = lambda: BatchRiskServiceStub()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/home/risk/batch",
+            json={
+                "sport": "SOCCER",
+                "profile": "ADULT",
+                "locations": [
+                    {"latitude": SYDNEY_LAT, "longitude": SYDNEY_LNG},
+                    {"latitude": MELBOURNE_LAT, "longitude": MELBOURNE_LNG},
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["locations"][0]["status"] == "ok"
+    assert body["locations"][1] == {
+        "latitude": MELBOURNE_LAT,
+        "longitude": MELBOURNE_LNG,
+        "timezone": "Australia/Melbourne",
+        "status": "error",
+        "current_risk_level_interpolated": None,
+        "today_max_risk_level_interpolated": None,
+        "current_time_local": None,
+        "error_code": "weather_provider_unavailable",
+        "detail": "Weather provider unavailable",
+    }
+
+
+def test_post_home_risk_batch_empty_locations_returns_422() -> None:
+    """An empty locations array should be rejected."""
+
+    app = create_app()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/home/risk/batch",
+            json={
+                "sport": "SOCCER",
+                "profile": "ADULT",
+                "locations": [],
+            },
+        )
+
+    assert response.status_code == 422
+
+
+def test_post_home_risk_batch_more_than_max_locations_returns_422() -> None:
+    """The batch schema should enforce the dashboard location cap."""
+
+    app = create_app()
+    locations = [
+        {"latitude": -33.0 - (index * 0.01), "longitude": 151.0 + (index * 0.01)}
+        for index in range(BATCH_RISK_LOCATION_MAX + 1)
+    ]
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/home/risk/batch",
+            json={
+                "sport": "SOCCER",
+                "profile": "ADULT",
+                "locations": locations,
+            },
+        )
+
+    assert response.status_code == 422
+
+
+def test_post_home_risk_batch_invalid_sport_returns_422() -> None:
+    """The batch request should require official pythermalcomfort sport names."""
+
+    app = create_app()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/home/risk/batch",
+            json={
+                "sport": "soccer",
+                "profile": "ADULT",
+                "locations": [{"latitude": SYDNEY_LAT, "longitude": SYDNEY_LNG}],
+            },
+        )
+
+    assert response.status_code == 422
+
+
+def test_post_home_risk_batch_invalid_longitude_returns_422() -> None:
+    """Invalid coordinates should be rejected before batch processing."""
+
+    app = create_app()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/home/risk/batch",
+            json={
+                "sport": "SOCCER",
+                "profile": "ADULT",
+                "locations": [{"latitude": SYDNEY_LAT, "longitude": 181.0}],
+            },
+        )
+
+    assert response.status_code == 422

--- a/backend/tests/clients/test_open_meteo.py
+++ b/backend/tests/clients/test_open_meteo.py
@@ -6,7 +6,10 @@ from zoneinfo import ZoneInfo
 import httpx
 import pytest
 
-from sma_extreme_heat_backend.clients.open_meteo import OpenMeteoClient
+from sma_extreme_heat_backend.clients.open_meteo import (
+    OpenMeteoClient,
+    WeatherLocationRequest,
+)
 from sma_extreme_heat_backend.core.errors import WeatherProviderError
 
 
@@ -494,8 +497,7 @@ async def test_fetch_weather_forecast_rejects_provider_timezone_mismatch() -> No
         )
     except WeatherProviderError as exc:
         assert (
-            exc.detail
-            == "Weather provider response timezone did not match the requested timezone"
+            exc.detail == "Weather provider response timezone did not match the requested timezone"
         )
     else:
         raise AssertionError("Expected WeatherProviderError for timezone mismatch")
@@ -608,3 +610,162 @@ async def test_fetch_weather_forecast_rejects_length_mismatch_for_direct_normal_
         raise AssertionError("Expected WeatherProviderError for radiation length mismatch")
     finally:
         await mock_client.aclose()
+
+
+async def test_fetch_weather_forecast_batch_returns_one_forecast_per_location() -> None:
+    """Multi-location responses should parse into aligned forecasts."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    payload = [
+        _hourly_payload(
+            times=[now],
+            tdb=[31.0],
+            rh=[62.0],
+            wind=[1.5],
+            radiation=[720.0],
+            timezone_name="Australia/Sydney",
+        ),
+        _hourly_payload(
+            times=[now],
+            tdb=[29.0],
+            rh=[60.0],
+            wind=[2.0],
+            radiation=[680.0],
+            timezone_name="Australia/Melbourne",
+        ),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params.get("latitude") == "-33.847,-37.813"
+        assert request.url.params.get("longitude") == "151.067,144.963"
+        assert request.url.params.get("timezone") == ("Australia/Sydney,Australia/Melbourne")
+        assert request.url.params.get("forecast_days") == "2"
+        return httpx.Response(status_code=200, json=payload)
+
+    client, mock_client = _build_client(handler)
+
+    results = await client.fetch_weather_forecast_batch(
+        locations=[
+            WeatherLocationRequest(
+                latitude=-33.847,
+                longitude=151.067,
+                timezone_name="Australia/Sydney",
+            ),
+            WeatherLocationRequest(
+                latitude=-37.813,
+                longitude=144.963,
+                timezone_name="Australia/Melbourne",
+            ),
+        ]
+    )
+    await mock_client.aclose()
+
+    assert len(results) == 2
+    assert results[0].error is None
+    assert results[0].forecast is not None
+    assert results[0].forecast.points[0].tdb == 31.0
+    assert results[1].forecast is not None
+    assert results[1].forecast.points[0].tdb == 29.0
+
+
+async def test_fetch_weather_forecast_batch_maps_per_location_parse_failures() -> None:
+    """One malformed location payload should not fail the rest of the chunk."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    payload = [
+        _hourly_payload(
+            times=[now],
+            tdb=[31.0],
+            rh=[62.0],
+            wind=[1.5],
+            radiation=[720.0],
+            timezone_name="Australia/Sydney",
+        ),
+        {
+            "timezone": "Australia/Melbourne",
+            "hourly_units": {
+                "temperature_2m": "°C",
+                "relative_humidity_2m": "%",
+                "wind_speed_10m": "m/s",
+                "direct_normal_irradiance": "W/m²",
+            },
+            "hourly": {
+                "time": ["invalid-time"],
+                "temperature_2m": [29.0],
+                "relative_humidity_2m": [60.0],
+                "wind_speed_10m": [2.0],
+                "direct_normal_irradiance": [680.0],
+            },
+        },
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=200, json=payload)
+
+    client, mock_client = _build_client(handler)
+
+    results = await client.fetch_weather_forecast_batch(
+        locations=[
+            WeatherLocationRequest(
+                latitude=-33.847,
+                longitude=151.067,
+                timezone_name="Australia/Sydney",
+            ),
+            WeatherLocationRequest(
+                latitude=-37.813,
+                longitude=144.963,
+                timezone_name="Australia/Melbourne",
+            ),
+        ]
+    )
+    await mock_client.aclose()
+
+    assert results[0].forecast is not None
+    assert results[1].forecast is None
+    assert results[1].error is not None
+    assert results[1].error.detail == (
+        "Weather provider response contained invalid hourly.time values"
+    )
+
+
+async def test_fetch_weather_forecast_batch_chunks_large_location_lists() -> None:
+    """Requests above the chunk size should fan out into multiple provider calls."""
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        location_count = len(request.url.params.get("latitude", "").split(","))
+        return httpx.Response(
+            status_code=200,
+            json=[
+                _hourly_payload(
+                    times=[now],
+                    tdb=[31.0],
+                    rh=[62.0],
+                    wind=[1.5],
+                    radiation=[720.0],
+                    timezone_name="Australia/Sydney",
+                )
+                for _ in range(location_count)
+            ],
+        )
+
+    client, mock_client = _build_client(handler)
+    locations = [
+        WeatherLocationRequest(
+            latitude=-33.847 + (index * 0.01),
+            longitude=151.067,
+            timezone_name="Australia/Sydney",
+        )
+        for index in range(11)
+    ]
+
+    results = await client.fetch_weather_forecast_batch(locations=locations)
+    await mock_client.aclose()
+
+    assert calls == 2
+    assert len(results) == 11
+    assert all(result.forecast is not None for result in results)

--- a/backend/tests/services/test_risk_batch_summary.py
+++ b/backend/tests/services/test_risk_batch_summary.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from sma_extreme_heat_backend.schemas.home import (
+    ForecastHeatRisk,
+    ForecastInputs,
+    ForecastPoint,
+)
+from sma_extreme_heat_backend.services.batch_summary import (
+    get_today_max_risk_level_interpolated,
+)
+
+
+def _forecast_point(
+    *,
+    time_local: str,
+    risk_level_interpolated: float,
+) -> ForecastPoint:
+    return ForecastPoint(
+        time_utc="2026-03-09T00:00:00Z",
+        time_local=time_local,
+        inputs=ForecastInputs(
+            air_temperature_c=31.0,
+            mean_radiant_temperature_c=37.25,
+            relative_humidity_pct=62.0,
+            wind_speed_10m_ms=1.5,
+            direct_normal_irradiance_wm2=700.0,
+        ),
+        heat_risk=ForecastHeatRisk(
+            risk_level_interpolated=risk_level_interpolated,
+            t_medium=34.5,
+            t_high=37.1,
+            t_extreme=39.2,
+            recommendation="Increase hydration & modify clothing",
+        ),
+    )
+
+
+def test_get_today_max_risk_level_interpolated_returns_single_point_value() -> None:
+    """A one-point forecast should use that point as today's max."""
+
+    forecast = [
+        _forecast_point(
+            time_local="2026-03-09T11:00:00+11:00",
+            risk_level_interpolated=1.2,
+        )
+    ]
+
+    assert get_today_max_risk_level_interpolated(forecast) == 1.2
+
+
+def test_get_today_max_risk_level_interpolated_returns_max_for_same_local_day() -> None:
+    """Today's max should include every hourly point on the current local date."""
+
+    forecast = [
+        _forecast_point(time_local="2026-03-09T11:00:00+11:00", risk_level_interpolated=1.2),
+        _forecast_point(time_local="2026-03-09T12:00:00+11:00", risk_level_interpolated=1.4),
+        _forecast_point(time_local="2026-03-09T13:00:00+11:00", risk_level_interpolated=1.9),
+    ]
+
+    assert get_today_max_risk_level_interpolated(forecast) == 1.9
+
+
+def test_get_today_max_risk_level_interpolated_ignores_later_local_days() -> None:
+    """Points on later local dates should not affect today's max."""
+
+    forecast = [
+        _forecast_point(time_local="2026-03-09T22:00:00+11:00", risk_level_interpolated=1.2),
+        _forecast_point(time_local="2026-03-09T23:00:00+11:00", risk_level_interpolated=1.5),
+        _forecast_point(time_local="2026-03-10T00:00:00+11:00", risk_level_interpolated=4.8),
+    ]
+
+    assert get_today_max_risk_level_interpolated(forecast) == 1.5
+
+
+def test_get_today_max_risk_level_interpolated_uses_first_point_local_date() -> None:
+    """The current local date should be derived from the earliest complete forecast point."""
+
+    forecast = [
+        _forecast_point(time_local="2026-03-09T23:30:00+10:30", risk_level_interpolated=2.0),
+        _forecast_point(time_local="2026-03-10T00:30:00+10:30", risk_level_interpolated=3.5),
+    ]
+
+    assert get_today_max_risk_level_interpolated(forecast) == 2.0
+
+
+def test_get_today_max_risk_level_interpolated_requires_forecast_points() -> None:
+    """An empty forecast should fail fast."""
+
+    with pytest.raises(ValueError, match="at least one point"):
+        get_today_max_risk_level_interpolated([])

--- a/backend/tests/services/test_risk_service.py
+++ b/backend/tests/services/test_risk_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import pandas as pd
@@ -9,8 +10,17 @@ from sma_extreme_heat_backend.calculators.sports_heat_stress import (
     SportsHeatStressInput,
     SportsHeatStressOutput,
 )
-from sma_extreme_heat_backend.clients.open_meteo import HourlyWeatherPoint, WeatherForecast
-from sma_extreme_heat_backend.core.errors import ModelInputUnavailableError
+from sma_extreme_heat_backend.clients.open_meteo import (
+    HourlyWeatherPoint,
+    LocationWeatherFetchResult,
+    WeatherForecast,
+)
+from sma_extreme_heat_backend.core.errors import ModelInputUnavailableError, WeatherProviderError
+from sma_extreme_heat_backend.schemas.batch import (
+    BatchRiskLocationRequest,
+    BatchRiskLocationStatus,
+    BatchRiskRequest,
+)
 from sma_extreme_heat_backend.schemas.home import RiskRequest
 from sma_extreme_heat_backend.services.risk_service import RiskService
 
@@ -82,6 +92,26 @@ class FakeCalculator:
         return SportsHeatStressOutput(
             data={
                 "risk_level_interpolated": round(1.84 + (self.calls * 0.1), 2),
+                "t_medium": 34.5,
+                "t_high": 37.1,
+                "t_extreme": 39.2,
+                "recommendation": "Increase hydration & modify clothing",
+            },
+            meta={
+                "model": "pythermalcomfort.models.sports_heat_stress_risk",
+            },
+        )
+
+
+class PerPointRiskCalculator(FakeCalculator):
+    """Calculator double keyed by air temperature for location-independent batch tests."""
+
+    def model_sports_heat_stress(self, payload: SportsHeatStressInput) -> SportsHeatStressOutput:
+        self.calls += 1
+        self.payloads.append(payload)
+        return SportsHeatStressOutput(
+            data={
+                "risk_level_interpolated": round(1.84 + ((payload.tdb - 30.0) * 0.1), 2),
                 "t_medium": 34.5,
                 "t_high": 37.1,
                 "t_extreme": 39.2,
@@ -261,6 +291,40 @@ async def test_risk_service_uses_ttl_cache_for_same_input(
             },
         },
     ]
+
+
+async def test_risk_service_batch_cache_expires_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expired dashboard summaries should be recomputed on the next request."""
+
+    import sma_extreme_heat_backend.services.risk_service as risk_service_module
+
+    clock = {"now": 1_000.0}
+    monkeypatch.setattr(risk_service_module.time, "monotonic", lambda: clock["now"])
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=10,
+    )
+    payload = BatchRiskRequest(
+        sport="SOCCER",
+        profile="ADULT",
+        locations=[BatchRiskLocationRequest(latitude=-33.847, longitude=151.067)],
+    )
+
+    await service.calculate_home_risk_batch(payload)
+    clock["now"] = 1_011.0
+    await service.calculate_home_risk_batch(payload)
+
+    assert weather_client.batch_calls == 2
 
 
 async def test_risk_service_cache_key_changes_with_coordinates(
@@ -591,3 +655,415 @@ async def test_risk_service_raises_422_when_no_complete_forecast_point_exists(
         }
     else:
         raise AssertionError("Expected ModelInputUnavailableError")
+
+
+class BatchWeatherClient:
+    """Weather client double that can fail for selected coordinates."""
+
+    def __init__(self, *, failing_longitudes: set[float] | None = None) -> None:
+        self.calls = 0
+        self.home_calls = 0
+        self.batch_calls = 0
+        self.failing_longitudes = failing_longitudes or set()
+        base_time = datetime(2026, 3, 9, 0, 0, tzinfo=UTC)
+        self.points = [
+            HourlyWeatherPoint(
+                time_utc=base_time + timedelta(hours=offset),
+                tdb=31.0 + offset,
+                rh=62.0 + offset,
+                wind=1.5 + (offset * 0.1),
+                radiation=700.0 + (offset * 50.0),
+            )
+            for offset in range(3)
+        ]
+
+    async def fetch_weather_forecast(
+        self,
+        *,
+        latitude: float,
+        longitude: float,
+        timezone_name: str,
+    ) -> WeatherForecast:
+        self.calls += 1
+        self.home_calls += 1
+        await asyncio.sleep(0)
+        if longitude in self.failing_longitudes:
+            raise WeatherProviderError()
+        return WeatherForecast(points=self.points)
+
+    async def fetch_weather_forecast_batch(
+        self,
+        *,
+        locations,
+    ) -> list[LocationWeatherFetchResult]:
+        self.calls += 1
+        self.batch_calls += 1
+        await asyncio.sleep(0)
+        results = []
+        for location in locations:
+            if location.longitude in self.failing_longitudes:
+                results.append(LocationWeatherFetchResult.failure(WeatherProviderError()))
+                continue
+            results.append(LocationWeatherFetchResult.success(WeatherForecast(points=self.points)))
+        return results
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _timezone_for_longitude(longitude: float) -> str:
+    if abs(longitude - 144.963) < 0.001:
+        return "Australia/Melbourne"
+    return "Australia/Sydney"
+
+
+async def test_risk_service_batch_returns_summary_for_multiple_locations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batch summaries should expose current and today's max risk per location."""
+
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+
+    response = await service.calculate_home_risk_batch(
+        BatchRiskRequest(
+            sport="SOCCER",
+            profile="ADULT",
+            locations=[
+                BatchRiskLocationRequest(latitude=-33.847, longitude=151.067),
+                BatchRiskLocationRequest(latitude=-37.813, longitude=144.963),
+            ],
+        )
+    )
+
+    assert response.request.model_dump() == {
+        "sport": "SOCCER",
+        "profile": "ADULT",
+    }
+    assert len(response.locations) == 2
+    assert response.locations[0].model_dump(mode="json") == {
+        "latitude": -33.847,
+        "longitude": 151.067,
+        "timezone": "Australia/Sydney",
+        "status": "ok",
+        "current_risk_level_interpolated": 1.94,
+        "today_max_risk_level_interpolated": 2.14,
+        "current_time_local": "2026-03-09T11:00:00+11:00",
+        "error_code": None,
+        "detail": None,
+    }
+    assert response.locations[1].status == BatchRiskLocationStatus.OK
+    assert response.locations[1].today_max_risk_level_interpolated == 2.14
+    assert weather_client.calls == 1
+
+
+async def test_risk_service_batch_returns_partial_errors_without_failing_whole_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One upstream failure should not prevent other locations from returning data."""
+
+    weather_client = BatchWeatherClient(failing_longitudes={144.963})
+    calculator = FakeCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+
+    response = await service.calculate_home_risk_batch(
+        BatchRiskRequest(
+            sport="SOCCER",
+            profile="ADULT",
+            locations=[
+                BatchRiskLocationRequest(latitude=-33.847, longitude=151.067),
+                BatchRiskLocationRequest(latitude=-37.813, longitude=144.963),
+            ],
+        )
+    )
+
+    assert response.locations[0].status == BatchRiskLocationStatus.OK
+    assert response.locations[1].model_dump(mode="json") == {
+        "latitude": -37.813,
+        "longitude": 144.963,
+        "timezone": "Australia/Melbourne",
+        "status": "error",
+        "current_risk_level_interpolated": None,
+        "today_max_risk_level_interpolated": None,
+        "current_time_local": None,
+        "error_code": "weather_provider_unavailable",
+        "detail": "Weather provider unavailable",
+    }
+
+
+async def test_risk_service_batch_fetches_duplicate_coordinates_in_one_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated coordinates in one batch should use one multi-location weather fetch."""
+
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+
+    await service.calculate_home_risk_batch(
+        BatchRiskRequest(
+            sport="SOCCER",
+            profile="ADULT",
+            locations=[
+                BatchRiskLocationRequest(latitude=-33.847, longitude=151.067),
+                BatchRiskLocationRequest(latitude=-33.847, longitude=151.067),
+            ],
+        )
+    )
+
+    assert weather_client.calls == 1
+    assert calculator.calls == 6
+
+
+async def test_risk_service_batch_uses_ttl_cache_for_successful_summaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated batch requests should reuse successful summaries within the TTL."""
+
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+    payload = BatchRiskRequest(
+        sport="SOCCER",
+        profile="ADULT",
+        locations=[
+            BatchRiskLocationRequest(latitude=-33.847, longitude=151.067),
+            BatchRiskLocationRequest(latitude=-37.813, longitude=144.963),
+        ],
+    )
+
+    first = await service.calculate_home_risk_batch(payload)
+    second = await service.calculate_home_risk_batch(payload)
+
+    assert weather_client.batch_calls == 1
+    assert calculator.calls == 6
+    assert first.locations == second.locations
+    assert first.locations[0].status == BatchRiskLocationStatus.OK
+    assert first.locations[1].status == BatchRiskLocationStatus.OK
+
+
+async def test_risk_service_batch_cache_keeps_locations_that_round_identically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Locations that collide at six decimals must not share a cache entry."""
+
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+    first_latitude = -33.8470001
+    second_latitude = -33.8470004
+    longitude = 151.067
+    assert first_latitude != second_latitude
+    assert f"{first_latitude:.6f}" == f"{second_latitude:.6f}"
+    payload = BatchRiskRequest(
+        sport="SOCCER",
+        profile="ADULT",
+        locations=[
+            BatchRiskLocationRequest(latitude=first_latitude, longitude=longitude),
+            BatchRiskLocationRequest(latitude=second_latitude, longitude=longitude),
+        ],
+    )
+
+    first = await service.calculate_home_risk_batch(payload)
+    second = await service.calculate_home_risk_batch(payload)
+
+    assert weather_client.batch_calls == 1
+    assert first.locations[0].latitude == first_latitude
+    assert first.locations[1].latitude == second_latitude
+    assert second.locations[0].latitude == first_latitude
+    assert second.locations[1].latitude == second_latitude
+    assert RiskService._batch_cache_key(
+        sport="SOCCER",
+        profile="ADULT",
+        latitude=first_latitude,
+        longitude=longitude,
+    ) != RiskService._batch_cache_key(
+        sport="SOCCER",
+        profile="ADULT",
+        latitude=second_latitude,
+        longitude=longitude,
+    )
+
+
+async def test_risk_service_batch_does_not_cache_location_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failed locations should be retried on the next batch request."""
+
+    weather_client = BatchWeatherClient(failing_longitudes={144.963})
+    calculator = FakeCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+    payload = BatchRiskRequest(
+        sport="SOCCER",
+        profile="ADULT",
+        locations=[
+            BatchRiskLocationRequest(latitude=-33.847, longitude=151.067),
+            BatchRiskLocationRequest(latitude=-37.813, longitude=144.963),
+        ],
+    )
+
+    first = await service.calculate_home_risk_batch(payload)
+    second = await service.calculate_home_risk_batch(payload)
+
+    assert first.locations[0].status == BatchRiskLocationStatus.OK
+    assert first.locations[1].status == BatchRiskLocationStatus.ERROR
+    assert second.locations[0].status == BatchRiskLocationStatus.OK
+    assert second.locations[1].status == BatchRiskLocationStatus.ERROR
+    assert weather_client.batch_calls == 2
+
+
+async def test_risk_service_batch_cache_does_not_populate_home_risk_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached dashboard summary must not satisfy a seven-day home risk request."""
+
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    monkeypatch.setattr(
+        "sma_extreme_heat_backend.services.risk_service.resolve_timezone_name",
+        lambda **kwargs: _timezone_for_longitude(kwargs["longitude"]),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+
+    await service.calculate_home_risk_batch(
+        BatchRiskRequest(
+            sport="SOCCER",
+            profile="ADULT",
+            locations=[BatchRiskLocationRequest(latitude=-33.847, longitude=151.067)],
+        )
+    )
+    await service.calculate_home_risk(
+        RiskRequest(
+            sport="SOCCER",
+            latitude=-33.847,
+            longitude=151.067,
+            profile="ADULT",
+        )
+    )
+
+    assert weather_client.batch_calls == 1
+    assert weather_client.home_calls == 1
+
+
+async def test_risk_service_batch_maps_missing_inputs_to_unknown_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing model inputs should map to a per-location unknown_inputs error."""
+
+    weather_client = BatchWeatherClient()
+    calculator = PerPointRiskCalculator()
+    _install_mrt_pipeline(
+        monkeypatch,
+        df=_build_mrt_dataframe(
+            current_missing={"wind"},
+            future_missing_by_row={1: {"wind"}, 2: {"wind"}},
+        ),
+    )
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+
+    response = await service.calculate_home_risk_batch(
+        BatchRiskRequest(
+            sport="SOCCER",
+            profile="ADULT",
+            locations=[BatchRiskLocationRequest(latitude=-33.847, longitude=151.067)],
+        )
+    )
+
+    assert response.locations[0].status == BatchRiskLocationStatus.ERROR
+    assert response.locations[0].error_code == "unknown_inputs"
+    assert response.locations[0].detail == "Required model inputs are missing or uncertain"
+
+
+async def test_risk_service_batch_logs_unexpected_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected failures should stay per-location and be logged."""
+
+    class ExplodingWeatherClient(BatchWeatherClient):
+        async def fetch_weather_forecast_batch(self, *, locations):
+            self.calls += 1
+            await asyncio.sleep(0)
+            raise RuntimeError("boom")
+
+    weather_client = ExplodingWeatherClient()
+    calculator = FakeCalculator()
+    _install_mrt_pipeline(monkeypatch, df=_build_mrt_dataframe())
+    service = RiskService(
+        weather_client=weather_client,
+        calculator=calculator,
+        ttl_seconds=600,
+    )
+
+    with caplog.at_level("ERROR"):
+        response = await service.calculate_home_risk_batch(
+            BatchRiskRequest(
+                sport="SOCCER",
+                profile="ADULT",
+                locations=[BatchRiskLocationRequest(latitude=-33.847, longitude=151.067)],
+            )
+        )
+
+    assert response.locations[0].status == BatchRiskLocationStatus.ERROR
+    assert response.locations[0].error_code == "risk_calculation_failed"
+    assert "Unexpected batch location failure" in caplog.text

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { resolveSupportedLanguage } from "@/i18n/language";
 import { AboutPage } from "@/pages/AboutPage";
 import { DetailedRecommendationsPage } from "@/pages/DetailedRecommendationsPage";
 import { HomePage } from "@/pages/HomePage";
+import { MultiCityPage } from "@/pages/MultiCityPage";
 
 const routerBasename =
   import.meta.env.BASE_URL === "/"
@@ -33,6 +34,10 @@ const router = createBrowserRouter(
         {
           index: true,
           element: <HomePage />,
+        },
+        {
+          path: "multicity",
+          element: <MultiCityPage />,
         },
         {
           path: "about",

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,3 +1,4 @@
 export const endpoints = {
   heatRisk: "/home/risk",
+  heatRiskBatch: "/home/risk/batch",
 } as const;

--- a/frontend/src/api/heatRiskBatch.test.ts
+++ b/frontend/src/api/heatRiskBatch.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchHeatRiskBatch,
+  isBatchHeatRiskApiResponse,
+} from "@/api/heatRiskBatch";
+
+const VALID_BATCH_RESPONSE = {
+  request: {
+    sport: "SOCCER",
+    profile: "ADULT",
+  },
+  locations: [
+    {
+      latitude: -33.847,
+      longitude: 151.067,
+      timezone: "Australia/Sydney",
+      status: "ok",
+      current_risk_level_interpolated: 1.94,
+      today_max_risk_level_interpolated: 2.14,
+      current_time_local: "2026-03-09T11:00:00+11:00",
+      error_code: null,
+      detail: null,
+    },
+    {
+      latitude: -37.813,
+      longitude: 144.963,
+      timezone: "Australia/Melbourne",
+      status: "error",
+      current_risk_level_interpolated: null,
+      today_max_risk_level_interpolated: null,
+      current_time_local: null,
+      error_code: "weather_provider_unavailable",
+      detail: "Weather provider unavailable",
+    },
+  ],
+};
+
+describe("fetchHeatRiskBatch", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("posts the batch payload to the batch endpoint", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(VALID_BATCH_RESPONSE), { status: 200 }),
+    );
+
+    const result = await fetchHeatRiskBatch({
+      sport: "SOCCER",
+      profile: "ADULT",
+      locations: [
+        { latitude: -33.847, longitude: 151.067 },
+        { latitude: -37.813, longitude: 144.963 },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/home/risk/batch",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          sport: "SOCCER",
+          profile: "ADULT",
+          locations: [
+            { latitude: -33.847, longitude: 151.067 },
+            { latitude: -37.813, longitude: 144.963 },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("validates the batch response contract", () => {
+    expect(isBatchHeatRiskApiResponse(VALID_BATCH_RESPONSE)).toBe(true);
+    expect(isBatchHeatRiskApiResponse({ request: {}, locations: [] })).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/api/heatRiskBatch.ts
+++ b/frontend/src/api/heatRiskBatch.ts
@@ -1,0 +1,190 @@
+import type { SportType } from "@/domain/sport";
+import { isApiError } from "@/api/apiErrors";
+import { endpoints } from "@/api/endpoints";
+import { httpClient, isApiBaseUrlConfigured } from "@/api/httpClient";
+import {
+  isHeatRiskProfile,
+  type HeatRiskProfile,
+} from "@/domain/heatRiskProfile";
+import { parseOffsetIsoDateTime } from "@/lib/offsetIsoDateTime";
+
+export interface BatchHeatRiskLocationRequest {
+  latitude: number;
+  longitude: number;
+}
+
+export interface BatchHeatRiskRequest {
+  sport: SportType;
+  profile: HeatRiskProfile;
+  locations: BatchHeatRiskLocationRequest[];
+}
+
+export type BatchHeatRiskLocationStatus = "ok" | "error";
+
+export interface BatchHeatRiskLocationResult {
+  latitude: number;
+  longitude: number;
+  timezone: string | null;
+  status: BatchHeatRiskLocationStatus;
+  current_risk_level_interpolated: number | null;
+  today_max_risk_level_interpolated: number | null;
+  current_time_local: string | null;
+  error_code: string | null;
+  detail: string | null;
+}
+
+export interface BatchHeatRiskRequestSummary {
+  sport: string;
+  profile: HeatRiskProfile;
+}
+
+export interface BatchHeatRiskApiResponse {
+  request: BatchHeatRiskRequestSummary;
+  locations: BatchHeatRiskLocationResult[];
+}
+
+export type BatchHeatRiskErrorReason =
+  | "missing_config"
+  | "abort"
+  | "http_status"
+  | "invalid_response"
+  | "network"
+  | "weather_provider_unavailable";
+
+export type BatchHeatRiskApiResult =
+  | {
+      ok: true;
+      data: BatchHeatRiskApiResponse;
+    }
+  | {
+      ok: false;
+      reason: BatchHeatRiskErrorReason;
+      status?: number;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isBatchHeatRiskLocationStatus(
+  value: unknown,
+): value is BatchHeatRiskLocationStatus {
+  return value === "ok" || value === "error";
+}
+
+function isValidOffsetIsoDateTime(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    parseOffsetIsoDateTime(value) !== null
+  );
+}
+
+function isBatchHeatRiskLocationResult(
+  value: unknown,
+): value is BatchHeatRiskLocationResult {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const currentRisk = value.current_risk_level_interpolated;
+  const todayMaxRisk = value.today_max_risk_level_interpolated;
+  const currentTimeLocal = value.current_time_local;
+
+  return (
+    isFiniteNumber(value.latitude) &&
+    isFiniteNumber(value.longitude) &&
+    (value.timezone === null || typeof value.timezone === "string") &&
+    isBatchHeatRiskLocationStatus(value.status) &&
+    (currentRisk === null || isFiniteNumber(currentRisk)) &&
+    (todayMaxRisk === null || isFiniteNumber(todayMaxRisk)) &&
+    (currentTimeLocal === null || isValidOffsetIsoDateTime(currentTimeLocal)) &&
+    (value.error_code === null || typeof value.error_code === "string") &&
+    (value.detail === null || typeof value.detail === "string")
+  );
+}
+
+function isBatchHeatRiskRequestSummary(
+  value: unknown,
+): value is BatchHeatRiskRequestSummary {
+  return (
+    isRecord(value) &&
+    typeof value.sport === "string" &&
+    value.sport.length > 0 &&
+    isHeatRiskProfile(value.profile)
+  );
+}
+
+/**
+ * Validates the backend batch heat-risk response payload shape at runtime.
+ */
+export function isBatchHeatRiskApiResponse(
+  value: unknown,
+): value is BatchHeatRiskApiResponse {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    isBatchHeatRiskRequestSummary(value.request) &&
+    Array.isArray(value.locations) &&
+    value.locations.every(isBatchHeatRiskLocationResult)
+  );
+}
+
+function toBatchHeatRiskErrorReason(error: unknown): BatchHeatRiskErrorReason {
+  if (isApiError(error)) {
+    return error.serverCode === "weather_provider_unavailable"
+      ? "weather_provider_unavailable"
+      : error.kind;
+  }
+
+  return "network";
+}
+
+/**
+ * Fetches and validates the raw backend batch heat-risk response payload.
+ */
+export async function fetchHeatRiskBatch(
+  payload: BatchHeatRiskRequest,
+  options?: { signal?: AbortSignal },
+): Promise<BatchHeatRiskApiResult> {
+  if (!isApiBaseUrlConfigured()) {
+    return {
+      ok: false,
+      reason: "missing_config",
+    };
+  }
+
+  try {
+    const response = await httpClient<unknown>(endpoints.heatRiskBatch, {
+      method: "POST",
+      body: JSON.stringify(payload),
+      signal: options?.signal,
+    });
+
+    if (!isBatchHeatRiskApiResponse(response)) {
+      return {
+        ok: false,
+        reason: "invalid_response",
+      };
+    }
+
+    return {
+      ok: true,
+      data: response,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: toBatchHeatRiskErrorReason(error),
+      ...(isApiError(error) && error.status !== undefined
+        ? { status: error.status }
+        : {}),
+    };
+  }
+}

--- a/frontend/src/app/layout/SiteHeader.tsx
+++ b/frontend/src/app/layout/SiteHeader.tsx
@@ -34,6 +34,7 @@ export function SiteHeader() {
   const navItems = [
     { label: t("nav.home"), to: "/" },
     { label: t("nav.about"), to: "/about" },
+    { label: t("nav.multicityDashboard"), to: "/multicity" },
   ];
   const mobileNavItems = [
     ...navItems,

--- a/frontend/src/components/multicity/CityCard.tsx
+++ b/frontend/src/components/multicity/CityCard.tsx
@@ -1,0 +1,296 @@
+import { Avatar, Badge, Box, Group, Paper, Stack, Text } from "@mantine/core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { CityCardActions } from "@/components/multicity/CityCardActions";
+import { CityCardSkeleton } from "@/components/multicity/MultiCitySkeletons";
+import {
+  buildMulticityHomePath,
+  formatSavedLocationSubtitle,
+  toSavedLocationAvatarLabel,
+  type SavedLocation,
+} from "@/domain/multicity";
+import {
+  toMulticityBatchErrorI18nKey,
+  toMulticityCardErrorI18nKey,
+  type MulticityCityCardState,
+} from "@/domain/multicityBatch";
+import type { SportType } from "@/domain/sport";
+import { createRiskLevelLabels } from "@/domain/riskLabels";
+import type { RiskLevel } from "@/domain/risk";
+import {
+  getRiskBadgeForegroundColor,
+  getRiskColor,
+  getRiskLevelI18nKeys,
+} from "@/domain/riskRegistry";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { CONTENT_GAP, CONTENT_PADDING } from "@/config/uiLayout";
+import {
+  CITY_CARD_CONTROL_LAYER_Z_INDEX,
+  CITY_CARD_HIT_LAYER_Z_INDEX,
+} from "@/config/uiScale";
+
+const RISK_BADGE_SHADOW = "0 10px 24px rgba(15, 23, 42, 0.08)";
+
+interface CityCardProps {
+  location: SavedLocation;
+  cardState: MulticityCityCardState;
+  sport: SportType;
+  index: number;
+  totalCount: number;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+function CityCardRiskBadge({
+  riskLevel,
+  size = "lg",
+}: {
+  riskLevel: RiskLevel;
+  size?: "md" | "lg" | "xl";
+}) {
+  const { t } = useTranslation();
+  const longRiskLabels = createRiskLevelLabels((key) => t(key), "long");
+
+  return (
+    <Badge
+      color={getRiskColor(riskLevel)}
+      size={size}
+      radius="xl"
+      styles={{
+        root: {
+          color: getRiskBadgeForegroundColor(riskLevel),
+          boxShadow: RISK_BADGE_SHADOW,
+          flexShrink: 0,
+        },
+        label: {
+          fontWeight: 700,
+          letterSpacing: "0.06em",
+        },
+      }}
+    >
+      {longRiskLabels[riskLevel].toUpperCase()}
+    </Badge>
+  );
+}
+
+function CityCardStatusContent({
+  cardState,
+  isMobile,
+}: {
+  cardState: MulticityCityCardState;
+  isMobile: boolean;
+}) {
+  const { t } = useTranslation();
+
+  if (cardState.status === "ok") {
+    if (isMobile) {
+      return (
+        <>
+          <CityCardRiskBadge riskLevel={cardState.currentRiskLevel} size="lg" />
+          <Text c="dimmed" fz="sm">
+            {t("home.sections.forecast.maxRiskLabel")}{" "}
+            <Text
+              component="span"
+              fw={600}
+              c={getRiskColor(cardState.todayMaxRiskLevel)}
+            >
+              {t(
+                getRiskLevelI18nKeys(cardState.todayMaxRiskLevel).levelKey,
+              ).toUpperCase()}
+            </Text>
+          </Text>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <CityCardRiskBadge riskLevel={cardState.currentRiskLevel} />
+        <Text c="dimmed" fz="sm">
+          {t("home.sections.forecast.maxRiskLabel")}{" "}
+          <Text
+            component="span"
+            fw={600}
+            c={getRiskColor(cardState.todayMaxRiskLevel)}
+          >
+            {t(
+              getRiskLevelI18nKeys(cardState.todayMaxRiskLevel).levelKey,
+            ).toUpperCase()}
+          </Text>
+        </Text>
+      </>
+    );
+  }
+
+  return (
+    <Text c="dimmed" fz="sm">
+      {cardState.status === "batch_error"
+        ? t(toMulticityBatchErrorI18nKey(cardState.reason))
+        : cardState.status === "location_error"
+          ? t(toMulticityCardErrorI18nKey(cardState.errorCode))
+          : t("multicity.cardErrors.missingResult")}
+    </Text>
+  );
+}
+
+function CityCardTitleLink({
+  homePath,
+  name,
+  ariaLabel,
+  lineClamp,
+}: {
+  homePath: string;
+  name: string;
+  ariaLabel: string;
+  lineClamp: number;
+}) {
+  return (
+    <Text
+      component={Link}
+      to={homePath}
+      fw={700}
+      lineClamp={lineClamp}
+      aria-label={ariaLabel}
+      c="inherit"
+      pos="relative"
+      style={{
+        textDecoration: "none",
+        zIndex: CITY_CARD_CONTROL_LAYER_Z_INDEX,
+      }}
+    >
+      {name}
+    </Text>
+  );
+}
+
+function CityCardHomeOverlay({ homePath }: { homePath: string }) {
+  return (
+    <Link
+      to={homePath}
+      tabIndex={-1}
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: CITY_CARD_HIT_LAYER_Z_INDEX,
+      }}
+    />
+  );
+}
+
+/**
+ * Renders a saved city card with current risk and today's max from batch data.
+ */
+export function CityCard({
+  location,
+  cardState,
+  sport,
+  index,
+  totalCount,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+}: CityCardProps) {
+  const { t } = useTranslation();
+  const isMobile = useIsMobileViewport();
+  const [isHovered, setIsHovered] = useState(false);
+  const locationSubtitle = formatSavedLocationSubtitle(location);
+  const shouldShowLocationSubtitle =
+    locationSubtitle.length > 0 && locationSubtitle !== location.name;
+  const homePath = buildMulticityHomePath(sport, location.displayLabel);
+  const openHomeAriaLabel = t("multicity.cards.openHomeAriaLabel", {
+    city: location.displayLabel,
+  });
+
+  if (cardState.status === "loading") {
+    return <CityCardSkeleton isMobile={isMobile} />;
+  }
+
+  const cardActionsProps = {
+    index,
+    totalCount,
+    onRemove,
+    onMoveUp,
+    onMoveDown,
+  };
+
+  return (
+    <Box
+      pos="relative"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Paper
+        withBorder
+        pos="relative"
+        radius="md"
+        p={CONTENT_PADDING.base}
+        style={{
+          minHeight: isMobile ? undefined : 160,
+          cursor: "pointer",
+        }}
+      >
+        {isMobile ? (
+          <Group align="flex-start" wrap="nowrap" gap="sm">
+            <Avatar radius="xl" color="brand" variant="light" size="md">
+              {toSavedLocationAvatarLabel(location.name)}
+            </Avatar>
+            <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
+              <Group wrap="nowrap" align="stretch" gap="xs">
+                <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+                  <CityCardTitleLink
+                    homePath={homePath}
+                    name={location.name}
+                    ariaLabel={openHomeAriaLabel}
+                    lineClamp={1}
+                  />
+                  {shouldShowLocationSubtitle ? (
+                    <Text c="dimmed" fz="sm" lineClamp={1}>
+                      {locationSubtitle}
+                    </Text>
+                  ) : null}
+                </Stack>
+                <Box style={{ alignSelf: "center", flexShrink: 0 }}>
+                  <CityCardActions
+                    {...cardActionsProps}
+                    isMobile={true}
+                    isVisible={true}
+                  />
+                </Box>
+              </Group>
+              <CityCardStatusContent cardState={cardState} isMobile={true} />
+            </Stack>
+          </Group>
+        ) : (
+          <Stack gap={CONTENT_GAP} justify="space-between" h="100%">
+            <Stack gap={4}>
+              <CityCardTitleLink
+                homePath={homePath}
+                name={location.name}
+                ariaLabel={openHomeAriaLabel}
+                lineClamp={2}
+              />
+              {shouldShowLocationSubtitle ? (
+                <Text c="dimmed" fz="sm" lineClamp={2}>
+                  {locationSubtitle}
+                </Text>
+              ) : null}
+            </Stack>
+            <CityCardStatusContent cardState={cardState} isMobile={false} />
+          </Stack>
+        )}
+        <CityCardHomeOverlay homePath={homePath} />
+      </Paper>
+
+      {!isMobile ? (
+        <CityCardActions
+          {...cardActionsProps}
+          isMobile={false}
+          isVisible={isHovered}
+        />
+      ) : null}
+    </Box>
+  );
+}

--- a/frontend/src/components/multicity/CityCardActions.tsx
+++ b/frontend/src/components/multicity/CityCardActions.tsx
@@ -1,0 +1,158 @@
+import { ActionIcon, Group, Menu, Tooltip } from "@mantine/core";
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconDots,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import {
+  UI_INLINE_ICON_SIZE,
+  UI_INLINE_ICON_STROKE,
+  MOBILE_CITY_CARD_ACTION_SIZE,
+  CITY_CARD_CONTROL_LAYER_Z_INDEX,
+} from "@/config/uiScale";
+
+interface CityCardActionsProps {
+  index: number;
+  totalCount: number;
+  isMobile: boolean;
+  isVisible: boolean;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+/**
+ * Renders delete and reorder controls for a city card.
+ */
+export function CityCardActions({
+  index,
+  totalCount,
+  isMobile,
+  isVisible,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+}: CityCardActionsProps) {
+  const { t } = useTranslation();
+  const canMoveUp = index > 0;
+  const canMoveDown = index < totalCount - 1;
+
+  const stopPropagation = (event: { stopPropagation: () => void }) => {
+    event.stopPropagation();
+  };
+
+  const handleRemove = (event: { stopPropagation: () => void }) => {
+    stopPropagation(event);
+    onRemove();
+  };
+
+  const handleMoveUp = (event: { stopPropagation: () => void }) => {
+    stopPropagation(event);
+    onMoveUp();
+  };
+
+  const handleMoveDown = (event: { stopPropagation: () => void }) => {
+    stopPropagation(event);
+    onMoveDown();
+  };
+
+  if (isMobile) {
+    return (
+      <Menu position="bottom-end" withinPortal>
+        <Menu.Target>
+          <ActionIcon
+            variant="light"
+            color="gray"
+            size={MOBILE_CITY_CARD_ACTION_SIZE}
+            radius="xl"
+            aria-label={t("multicity.cards.menuAriaLabel")}
+            onClick={stopPropagation}
+            style={{
+              position: "relative",
+              zIndex: CITY_CARD_CONTROL_LAYER_Z_INDEX,
+            }}
+          >
+            <IconDots
+              size={UI_INLINE_ICON_SIZE}
+              stroke={UI_INLINE_ICON_STROKE}
+            />
+          </ActionIcon>
+        </Menu.Target>
+        <Menu.Dropdown>
+          <Menu.Item disabled={!canMoveUp} onClick={handleMoveUp}>
+            {t("multicity.cards.moveUp")}
+          </Menu.Item>
+          <Menu.Item disabled={!canMoveDown} onClick={handleMoveDown}>
+            {t("multicity.cards.moveDown")}
+          </Menu.Item>
+          <Menu.Item color="red" onClick={handleRemove}>
+            {t("multicity.cards.delete")}
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    );
+  }
+
+  return (
+    <Group
+      gap={4}
+      wrap="nowrap"
+      style={{
+        position: "absolute",
+        top: 8,
+        right: 8,
+        zIndex: CITY_CARD_CONTROL_LAYER_Z_INDEX,
+        opacity: isVisible ? 1 : 0,
+        transition: "opacity 150ms ease",
+        pointerEvents: isVisible ? "auto" : "none",
+      }}
+    >
+      <Tooltip label={t("multicity.cards.moveLeft")}>
+        <ActionIcon
+          variant="light"
+          color="gray"
+          size="sm"
+          aria-label={t("multicity.cards.moveLeft")}
+          disabled={!canMoveUp}
+          onClick={handleMoveUp}
+        >
+          <IconChevronLeft
+            size={UI_INLINE_ICON_SIZE}
+            stroke={UI_INLINE_ICON_STROKE}
+          />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label={t("multicity.cards.moveRight")}>
+        <ActionIcon
+          variant="light"
+          color="gray"
+          size="sm"
+          aria-label={t("multicity.cards.moveRight")}
+          disabled={!canMoveDown}
+          onClick={handleMoveDown}
+        >
+          <IconChevronRight
+            size={UI_INLINE_ICON_SIZE}
+            stroke={UI_INLINE_ICON_STROKE}
+          />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label={t("multicity.cards.delete")}>
+        <ActionIcon
+          variant="light"
+          color="red"
+          size="sm"
+          aria-label={t("multicity.cards.delete")}
+          onClick={handleRemove}
+        >
+          <IconTrash
+            size={UI_INLINE_ICON_SIZE}
+            stroke={UI_INLINE_ICON_STROKE}
+          />
+        </ActionIcon>
+      </Tooltip>
+    </Group>
+  );
+}

--- a/frontend/src/components/multicity/CityCardList.tsx
+++ b/frontend/src/components/multicity/CityCardList.tsx
@@ -1,0 +1,51 @@
+import { SimpleGrid, Stack } from "@mantine/core";
+import { CityCard } from "@/components/multicity/CityCard";
+import { CONTENT_GAP } from "@/config/uiLayout";
+import type { SavedLocation } from "@/domain/multicity";
+import type { MulticityCityCardState } from "@/domain/multicityBatch";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import { useMulticityStore } from "@/store/multicityStore";
+
+interface CityCardListProps {
+  locations: SavedLocation[];
+  getCardState: (location: SavedLocation) => MulticityCityCardState;
+}
+
+/**
+ * Renders saved city cards in a responsive grid or vertical list.
+ */
+export function CityCardList({ locations, getCardState }: CityCardListProps) {
+  const isMobile = useIsMobileViewport();
+  const sport = useMulticityStore((state) => state.sport);
+  const removeLocation = useMulticityStore((state) => state.removeLocation);
+  const moveLocationUp = useMulticityStore((state) => state.moveLocationUp);
+  const moveLocationDown = useMulticityStore((state) => state.moveLocationDown);
+
+  const renderCard = (location: SavedLocation, index: number) => (
+    <CityCard
+      key={location.id}
+      location={location}
+      cardState={getCardState(location)}
+      sport={sport}
+      index={index}
+      totalCount={locations.length}
+      onRemove={() => removeLocation(location.id)}
+      onMoveUp={() => moveLocationUp(location.id)}
+      onMoveDown={() => moveLocationDown(location.id)}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <Stack gap={CONTENT_GAP}>
+        {locations.map((location, index) => renderCard(location, index))}
+      </Stack>
+    );
+  }
+
+  return (
+    <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing={CONTENT_GAP}>
+      {locations.map((location, index) => renderCard(location, index))}
+    </SimpleGrid>
+  );
+}

--- a/frontend/src/components/multicity/MultiCityMainPanel.tsx
+++ b/frontend/src/components/multicity/MultiCityMainPanel.tsx
@@ -1,0 +1,181 @@
+import {
+  Combobox,
+  Group,
+  InputBase,
+  Loader,
+  Select,
+  Stack,
+  Text,
+  useCombobox,
+} from "@mantine/core";
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { SectionCard } from "@/components/ui/SectionCard";
+import { CONTENT_GAP } from "@/config/uiLayout";
+import { isSportType, sports, type SportType } from "@/domain/sport";
+import { useMulticityLocationAdd } from "@/hooks/useMulticityLocationAdd";
+import { useMulticityStore } from "@/store/multicityStore";
+
+interface SelectOption<T extends string = string> {
+  value: T;
+  label: string;
+}
+
+interface MultiCityMainPanelProps {
+  onAddError?: (
+    reason: NonNullable<
+      ReturnType<typeof useMulticityLocationAdd>["addErrorReason"]
+    >,
+  ) => void;
+}
+
+/**
+ * Renders the main multi-city panel with title, inline sport filter, and add-location search.
+ */
+export function MultiCityMainPanel({ onAddError }: MultiCityMainPanelProps) {
+  const { t } = useTranslation();
+  const locationCombobox = useCombobox();
+  const sport = useMulticityStore((state) => state.sport);
+  const setSport = useMulticityStore((state) => state.setSport);
+  const locations = useMulticityStore((state) => state.locations);
+  const {
+    locationSearchInput,
+    locationSuggestions,
+    isSuggestLoading,
+    isAddingLocation,
+    canAddMoreLocations,
+    addErrorReason,
+    onLocationSearchInputChange,
+    onLocationOptionSubmit,
+  } = useMulticityLocationAdd();
+
+  const sportOptions = useMemo<SelectOption<SportType>[]>(
+    () =>
+      sports.map((sportMeta) => ({
+        value: sportMeta.type,
+        label: t(sportMeta.labelKey),
+      })),
+    [t],
+  );
+
+  const handleSportChange = (value: string | null) => {
+    if (value !== null && isSportType(value)) {
+      setSport(value);
+    }
+  };
+
+  const shouldRenderLocationDropdown = locationSuggestions.length > 0;
+  const locationRightSection =
+    isSuggestLoading || isAddingLocation ? (
+      <Loader size={16} />
+    ) : (
+      <Combobox.Chevron size="md" />
+    );
+  const locationOptions = locationSuggestions.map((suggestion) => (
+    <Combobox.Option value={suggestion.id} key={suggestion.id}>
+      {suggestion.displayLabel}
+    </Combobox.Option>
+  ));
+
+  useEffect(() => {
+    if (shouldRenderLocationDropdown) {
+      locationCombobox.openDropdown();
+    }
+  }, [locationCombobox, shouldRenderLocationDropdown]);
+
+  useEffect(() => {
+    if (addErrorReason) {
+      onAddError?.(addErrorReason);
+    }
+  }, [addErrorReason, onAddError]);
+
+  const closeLocationDropdown = () => {
+    locationCombobox.closeDropdown();
+    locationCombobox.resetSelectedOption();
+  };
+
+  return (
+    <SectionCard title={t("multicity.header.title")}>
+      <Stack gap={CONTENT_GAP}>
+        <Group wrap="wrap" align="center" gap="xs">
+          <Text c="dimmed" fz={{ base: "md", sm: "lg" }}>
+            {t("multicity.header.subtitlePrefix")}
+          </Text>
+          <Select
+            aria-label={t("multicity.header.sportLabel")}
+            size="md"
+            data={sportOptions}
+            value={sport}
+            onChange={handleSportChange}
+            searchable
+            nothingFoundMessage={t("multicity.header.sportNotFound")}
+            maw={280}
+            flex={1}
+            styles={{
+              root: {
+                flexGrow: 1,
+                minWidth: 180,
+                maxWidth: 320,
+              },
+            }}
+          />
+        </Group>
+
+        <Stack gap="xs">
+          <Text fw={600}>{t("multicity.addLocation.title")}</Text>
+          <Combobox
+            store={locationCombobox}
+            onOptionSubmit={(value) => {
+              onLocationOptionSubmit(value);
+              closeLocationDropdown();
+            }}
+            size="md"
+          >
+            <Combobox.Target targetType="input">
+              <InputBase
+                __staticSelector="Select"
+                aria-label={t("multicity.addLocation.inputLabel")}
+                size="md"
+                placeholder={t("multicity.addLocation.placeholder")}
+                value={locationSearchInput}
+                onChange={(event) => {
+                  onLocationSearchInputChange(event.currentTarget.value);
+                  locationCombobox.openDropdown();
+                }}
+                onFocus={() => {
+                  if (shouldRenderLocationDropdown) {
+                    locationCombobox.openDropdown();
+                  }
+                }}
+                onBlur={closeLocationDropdown}
+                rightSection={locationRightSection}
+                rightSectionPointerEvents="none"
+                autoComplete="off"
+                disabled={!canAddMoreLocations || isAddingLocation}
+              />
+            </Combobox.Target>
+
+            {shouldRenderLocationDropdown ? (
+              <Combobox.Dropdown>
+                <Combobox.Options>{locationOptions}</Combobox.Options>
+              </Combobox.Dropdown>
+            ) : null}
+          </Combobox>
+
+          {!canAddMoreLocations ? (
+            <Text c="dimmed" fz="sm">
+              {t("multicity.errors.max_reached")}
+            </Text>
+          ) : null}
+        </Stack>
+
+        {locations.length === 0 ? (
+          <Stack gap="xs">
+            <Text fw={600}>{t("multicity.emptyState.title")}</Text>
+            <Text c="dimmed">{t("multicity.emptyState.body")}</Text>
+          </Stack>
+        ) : null}
+      </Stack>
+    </SectionCard>
+  );
+}

--- a/frontend/src/components/multicity/MultiCitySkeletons.tsx
+++ b/frontend/src/components/multicity/MultiCitySkeletons.tsx
@@ -1,0 +1,59 @@
+import { Group, Paper, Skeleton, Stack } from "@mantine/core";
+import { CONTENT_GAP, CONTENT_PADDING } from "@/config/uiLayout";
+import { MOBILE_CITY_CARD_ACTION_SIZE } from "@/config/uiScale";
+
+interface CityCardSkeletonProps {
+  isMobile?: boolean;
+}
+
+/**
+ * Renders a skeleton placeholder while a city card's batch risk data loads.
+ */
+export function CityCardSkeleton({ isMobile = false }: CityCardSkeletonProps) {
+  if (isMobile) {
+    return (
+      <Paper withBorder radius="md" p={CONTENT_PADDING.base}>
+        <Group align="flex-start" wrap="nowrap" gap="sm">
+          <Skeleton h={40} w={40} circle />
+          <Stack gap="xs" style={{ flex: 1 }}>
+            <Group align="stretch" wrap="nowrap" gap="xs">
+              <Stack gap={4} style={{ flex: 1 }}>
+                <Skeleton h={20} w="55%" radius="sm" />
+                <Skeleton h={14} w="70%" radius="sm" />
+              </Stack>
+              <Skeleton
+                style={{
+                  alignSelf: "center",
+                  flexShrink: 0,
+                  height: MOBILE_CITY_CARD_ACTION_SIZE,
+                  width: MOBILE_CITY_CARD_ACTION_SIZE,
+                }}
+                circle
+              />
+            </Group>
+            <Skeleton h={28} w={80} radius="xl" />
+            <Skeleton h={14} w="70%" radius="sm" />
+          </Stack>
+        </Group>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper
+      withBorder
+      radius="md"
+      p={CONTENT_PADDING.base}
+      style={{ minHeight: 160 }}
+    >
+      <Stack gap={CONTENT_GAP} justify="space-between" h="100%">
+        <Stack gap={4}>
+          <Skeleton h={24} w="70%" radius="sm" />
+          <Skeleton h={16} w="55%" radius="sm" />
+        </Stack>
+        <Skeleton h={32} w={112} radius="xl" />
+        <Skeleton h={16} w="80%" radius="sm" />
+      </Stack>
+    </Paper>
+  );
+}

--- a/frontend/src/config/uiScale.ts
+++ b/frontend/src/config/uiScale.ts
@@ -7,3 +7,8 @@ export const UI_TITLE_THEME_ICON_SIZE = "xl";
 
 export const COMPACT_RECOMMENDATION_LAYOUT_QUERY = "(max-width: 36em)";
 export const ACTION_IMAGE_ICON_SIZE = "calc(var(--mantine-font-size-md) * 2.5)";
+
+/** Pixel size for mobile city-card menu buttons, matching risk badges and skeletons. */
+export const MOBILE_CITY_CARD_ACTION_SIZE = 34;
+export const CITY_CARD_HIT_LAYER_Z_INDEX = 1;
+export const CITY_CARD_CONTROL_LAYER_Z_INDEX = 2;

--- a/frontend/src/domain/multicity.test.ts
+++ b/frontend/src/domain/multicity.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  canAddSavedLocation,
+  createSavedLocationFromSuggestion,
+  formatSavedLocationSubtitle,
+  buildMulticityHomePath,
+  toSavedLocationAvatarLabel,
+  isDuplicateSavedLocation,
+  MAX_SAVED_LOCATIONS,
+  validateAddSavedLocation,
+  type SavedLocation,
+} from "@/domain/multicity";
+import { SportType } from "@/domain/sport";
+import type { LocationSuggestion } from "@/domain/location";
+
+const BASE_SUGGESTION: LocationSuggestion = {
+  id: "suggestion-1",
+  displayLabel: "Sydney, New South Wales, Australia",
+  name: "Sydney",
+  regionName: "New South Wales",
+  countryName: "Australia",
+  mapboxId: "mapbox-sydney",
+  latitude: -33.847,
+  longitude: 151.067,
+};
+
+function createSavedLocation(
+  overrides: Partial<SavedLocation> = {},
+): SavedLocation {
+  return {
+    id: "location-1",
+    displayLabel: "Sydney, New South Wales, Australia",
+    name: "Sydney",
+    regionName: "New South Wales",
+    countryName: "Australia",
+    latitude: -33.847,
+    longitude: 151.067,
+    mapboxId: "mapbox-sydney",
+    ...overrides,
+  };
+}
+
+describe("multicity domain", () => {
+  it("creates a saved location from a resolved suggestion", () => {
+    const savedLocation = createSavedLocationFromSuggestion({
+      ...BASE_SUGGESTION,
+      latitude: -33.847,
+      longitude: 151.067,
+    });
+
+    expect(savedLocation).toMatchObject({
+      displayLabel: BASE_SUGGESTION.displayLabel,
+      name: "Sydney",
+      latitude: -33.847,
+      longitude: 151.067,
+      mapboxId: "mapbox-sydney",
+    });
+    expect(savedLocation.id.length).toBeGreaterThan(0);
+  });
+
+  it("detects duplicate locations by mapbox id or coordinates", () => {
+    const locations = [createSavedLocation()];
+
+    expect(
+      isDuplicateSavedLocation(locations, {
+        latitude: -33.847,
+        longitude: 151.067,
+        mapboxId: "mapbox-sydney",
+      }),
+    ).toBe(true);
+
+    expect(
+      isDuplicateSavedLocation(locations, {
+        latitude: -37.813,
+        longitude: 144.963,
+        mapboxId: "mapbox-melbourne",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats matching coordinates as duplicates when mapbox ids differ", () => {
+    const locations = [createSavedLocation({ mapboxId: "session-a-sydney" })];
+
+    expect(
+      isDuplicateSavedLocation(locations, {
+        latitude: -33.847,
+        longitude: 151.067,
+        mapboxId: "session-b-sydney",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats matching mapbox ids as duplicates even when coordinates differ", () => {
+    const locations = [createSavedLocation()];
+
+    expect(
+      isDuplicateSavedLocation(locations, {
+        latitude: -33.9,
+        longitude: 151.2,
+        mapboxId: "mapbox-sydney",
+      }),
+    ).toBe(true);
+  });
+
+  it("enforces the max saved location limit", () => {
+    const locations = Array.from({ length: MAX_SAVED_LOCATIONS }, (_, index) =>
+      createSavedLocation({
+        id: `location-${index}`,
+        displayLabel: `City ${index}`,
+        name: `City ${index}`,
+        latitude: -33 + index * 0.01,
+        longitude: 151 + index * 0.01,
+        mapboxId: `mapbox-${index}`,
+      }),
+    );
+
+    expect(canAddSavedLocation(locations)).toBe(false);
+    expect(validateAddSavedLocation(locations, BASE_SUGGESTION)).toEqual({
+      ok: false,
+      reason: "max_reached",
+    });
+  });
+
+  it("rejects suggestions without coordinates", () => {
+    expect(
+      validateAddSavedLocation([], {
+        ...BASE_SUGGESTION,
+        latitude: undefined,
+        longitude: undefined,
+      }),
+    ).toEqual({
+      ok: false,
+      reason: "missing_coordinates",
+    });
+  });
+
+  it("formats saved location subtitles from region and country", () => {
+    expect(
+      formatSavedLocationSubtitle({
+        name: "Richmond",
+        regionName: "Victoria",
+        countryName: "Australia",
+      }),
+    ).toBe("Victoria, Australia");
+
+    expect(
+      formatSavedLocationSubtitle({
+        name: "Richmond",
+        regionName: "New South Wales",
+        countryName: "Australia",
+      }),
+    ).toBe("New South Wales, Australia");
+
+    expect(
+      formatSavedLocationSubtitle({
+        name: "Singapore",
+        countryName: "Singapore",
+      }),
+    ).toBe("Singapore");
+  });
+
+  it("builds home navigation URLs with multicity sport and location label", () => {
+    expect(
+      buildMulticityHomePath(
+        SportType.Soccer,
+        "Sydney, New South Wales, Australia",
+      ),
+    ).toBe("/?sport=SOCCER&loc=Sydney%2C+New+South+Wales%2C+Australia");
+  });
+
+  it("builds mobile avatar labels from city names", () => {
+    expect(toSavedLocationAvatarLabel("Sydney")).toBe("S");
+    expect(toSavedLocationAvatarLabel("  ")).toBe("?");
+  });
+});

--- a/frontend/src/domain/multicity.ts
+++ b/frontend/src/domain/multicity.ts
@@ -1,0 +1,154 @@
+import type { LocationSuggestion } from "@/domain/location";
+
+export const MAX_SAVED_LOCATIONS = 6;
+export const COORDINATE_KEY_DECIMALS = 6;
+
+export interface SavedLocation {
+  id: string;
+  displayLabel: string;
+  name: string;
+  regionName?: string;
+  countryName: string;
+  latitude: number;
+  longitude: number;
+  mapboxId?: string;
+}
+
+export type AddLocationFailureReason =
+  | "duplicate"
+  | "max_reached"
+  | "missing_coordinates";
+
+export type AddLocationResult =
+  | { ok: true }
+  | { ok: false; reason: AddLocationFailureReason };
+
+export function toCoordinateKey(latitude: number, longitude: number): string {
+  return `${latitude.toFixed(COORDINATE_KEY_DECIMALS)}|${longitude.toFixed(COORDINATE_KEY_DECIMALS)}`;
+}
+
+/**
+ * Builds the secondary city label shown beneath the primary city name on cards.
+ */
+export function formatSavedLocationSubtitle(
+  location: Pick<SavedLocation, "name" | "regionName" | "countryName">,
+): string {
+  return [location.regionName, location.countryName]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(", ");
+}
+
+/**
+ * Builds the home page URL for a saved dashboard location.
+ */
+export function buildMulticityHomePath(
+  sport: string,
+  displayLabel: string,
+): string {
+  const searchParams = new URLSearchParams();
+  searchParams.set("sport", sport);
+  searchParams.set("loc", displayLabel);
+
+  return `/?${searchParams.toString()}`;
+}
+
+/**
+ * Returns the first visible character for a mobile city avatar.
+ */
+export function toSavedLocationAvatarLabel(name: string): string {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return "?";
+  }
+
+  return trimmedName.charAt(0).toUpperCase();
+}
+
+export function canAddSavedLocation(
+  locations: readonly SavedLocation[],
+): boolean {
+  return locations.length < MAX_SAVED_LOCATIONS;
+}
+
+/**
+ * Returns true when the candidate matches a saved city by mapbox id or coordinates.
+ * Mapbox Search Box ids are session-scoped, so equal ids are sufficient but not required.
+ */
+export function isDuplicateSavedLocation(
+  locations: readonly SavedLocation[],
+  candidate: Pick<SavedLocation, "latitude" | "longitude" | "mapboxId">,
+): boolean {
+  const candidateKey = toCoordinateKey(candidate.latitude, candidate.longitude);
+
+  return locations.some((location) => {
+    if (
+      location.mapboxId &&
+      candidate.mapboxId &&
+      location.mapboxId === candidate.mapboxId
+    ) {
+      return true;
+    }
+
+    return (
+      toCoordinateKey(location.latitude, location.longitude) === candidateKey
+    );
+  });
+}
+
+function createSavedLocationId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return `location-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+/**
+ * Builds a persisted dashboard location from a resolved Mapbox suggestion.
+ */
+export function createSavedLocationFromSuggestion(
+  suggestion: LocationSuggestion & { latitude: number; longitude: number },
+): SavedLocation {
+  return {
+    id: createSavedLocationId(),
+    displayLabel: suggestion.displayLabel,
+    name: suggestion.name,
+    regionName: suggestion.regionName,
+    countryName: suggestion.countryName,
+    latitude: suggestion.latitude,
+    longitude: suggestion.longitude,
+    mapboxId: suggestion.mapboxId,
+  };
+}
+
+/**
+ * Validates whether a resolved suggestion can be appended to the dashboard list.
+ */
+export function validateAddSavedLocation(
+  locations: readonly SavedLocation[],
+  suggestion: LocationSuggestion,
+): AddLocationResult {
+  if (!canAddSavedLocation(locations)) {
+    return { ok: false, reason: "max_reached" };
+  }
+
+  if (suggestion.latitude === undefined || suggestion.longitude === undefined) {
+    return { ok: false, reason: "missing_coordinates" };
+  }
+
+  if (
+    isDuplicateSavedLocation(locations, {
+      latitude: suggestion.latitude,
+      longitude: suggestion.longitude,
+      mapboxId: suggestion.mapboxId,
+    })
+  ) {
+    return { ok: false, reason: "duplicate" };
+  }
+
+  return { ok: true };
+}

--- a/frontend/src/domain/multicityBatch.test.ts
+++ b/frontend/src/domain/multicityBatch.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { BatchHeatRiskLocationResult } from "@/api/heatRiskBatch";
+import type { SavedLocation } from "@/domain/multicity";
+import {
+  buildMulticityLocationCoordsKey,
+  indexBatchResultsByCoordinateKey,
+  resolveMulticityCityCardState,
+  toMulticityCardErrorI18nKey,
+} from "@/domain/multicityBatch";
+
+const SYDNEY_LOCATION: SavedLocation = {
+  id: "location-sydney",
+  displayLabel: "Sydney, New South Wales, Australia",
+  name: "Sydney",
+  regionName: "New South Wales",
+  countryName: "Australia",
+  latitude: -33.847,
+  longitude: 151.067,
+  mapboxId: "mapbox-sydney",
+};
+
+const MELBOURNE_LOCATION: SavedLocation = {
+  id: "location-melbourne",
+  displayLabel: "Melbourne, Victoria, Australia",
+  name: "Melbourne",
+  regionName: "Victoria",
+  countryName: "Australia",
+  latitude: -37.813,
+  longitude: 144.963,
+  mapboxId: "mapbox-melbourne",
+};
+
+const OK_SYDNEY_RESULT: BatchHeatRiskLocationResult = {
+  latitude: -33.847,
+  longitude: 151.067,
+  timezone: "Australia/Sydney",
+  status: "ok",
+  current_risk_level_interpolated: 1.94,
+  today_max_risk_level_interpolated: 2.14,
+  current_time_local: "2026-03-09T11:00:00+11:00",
+  error_code: null,
+  detail: null,
+};
+
+const ERROR_MELBOURNE_RESULT: BatchHeatRiskLocationResult = {
+  latitude: -37.813,
+  longitude: 144.963,
+  timezone: null,
+  status: "error",
+  current_risk_level_interpolated: null,
+  today_max_risk_level_interpolated: null,
+  current_time_local: null,
+  error_code: "weather_provider_unavailable",
+  detail: "Weather provider unavailable",
+};
+
+describe("multicityBatch domain", () => {
+  it("builds a stable coordinate key for batch requests", () => {
+    expect(
+      buildMulticityLocationCoordsKey([SYDNEY_LOCATION, MELBOURNE_LOCATION]),
+    ).toBe("-33.847000|151.067000;-37.813000|144.963000");
+  });
+
+  it("ignores saved location order when building the coordinate key", () => {
+    expect(
+      buildMulticityLocationCoordsKey([MELBOURNE_LOCATION, SYDNEY_LOCATION]),
+    ).toBe(
+      buildMulticityLocationCoordsKey([SYDNEY_LOCATION, MELBOURNE_LOCATION]),
+    );
+  });
+
+  it("indexes batch results by normalized coordinates", () => {
+    const indexedResults = indexBatchResultsByCoordinateKey([
+      OK_SYDNEY_RESULT,
+      ERROR_MELBOURNE_RESULT,
+    ]);
+
+    expect(indexedResults.get("-33.847000|151.067000")?.status).toBe("ok");
+    expect(indexedResults.get("-37.813000|144.963000")?.error_code).toBe(
+      "weather_provider_unavailable",
+    );
+  });
+
+  it("resolves per-card states for success, error, and missing results", () => {
+    const indexedResults = indexBatchResultsByCoordinateKey([
+      OK_SYDNEY_RESULT,
+      ERROR_MELBOURNE_RESULT,
+    ]);
+
+    expect(
+      resolveMulticityCityCardState(SYDNEY_LOCATION, indexedResults),
+    ).toEqual({
+      status: "ok",
+      currentRiskLevel: "low",
+      todayMaxRiskLevel: "moderate",
+    });
+
+    expect(
+      resolveMulticityCityCardState(MELBOURNE_LOCATION, indexedResults),
+    ).toEqual({
+      status: "location_error",
+      errorCode: "weather_provider_unavailable",
+      detail: "Weather provider unavailable",
+    });
+
+    expect(
+      resolveMulticityCityCardState(
+        { ...SYDNEY_LOCATION, latitude: 1, longitude: 2 },
+        indexedResults,
+      ),
+    ).toEqual({
+      status: "missing_result",
+    });
+  });
+
+  it("treats a missing location as loading while a batch fetch is in flight", () => {
+    const indexedResults = indexBatchResultsByCoordinateKey([OK_SYDNEY_RESULT]);
+
+    expect(
+      resolveMulticityCityCardState(MELBOURNE_LOCATION, indexedResults, {
+        isFetching: true,
+      }),
+    ).toEqual({
+      status: "loading",
+    });
+
+    expect(
+      resolveMulticityCityCardState(MELBOURNE_LOCATION, indexedResults, {
+        isFetching: false,
+      }),
+    ).toEqual({
+      status: "missing_result",
+    });
+  });
+
+  it("maps known card error codes to i18n keys", () => {
+    expect(toMulticityCardErrorI18nKey("weather_provider_unavailable")).toBe(
+      "errors.risk.weatherProvider",
+    );
+    expect(toMulticityCardErrorI18nKey("unknown_inputs")).toBe(
+      "multicity.cardErrors.unknownInputs",
+    );
+    expect(toMulticityCardErrorI18nKey("custom_error")).toBe(
+      "multicity.cardErrors.generic",
+    );
+  });
+});

--- a/frontend/src/domain/multicityBatch.ts
+++ b/frontend/src/domain/multicityBatch.ts
@@ -1,0 +1,150 @@
+import type { BatchHeatRiskLocationResult } from "@/api/heatRiskBatch";
+import type { RiskLevel } from "@/domain/risk";
+import { toRiskLevel } from "@/domain/risk";
+import { toCoordinateKey, type SavedLocation } from "@/domain/multicity";
+
+export type MulticityBatchFetchErrorReason =
+  | "missing_config"
+  | "abort"
+  | "http_status"
+  | "invalid_response"
+  | "network"
+  | "weather_provider_unavailable";
+
+export type MulticityCityCardState =
+  | { status: "loading" }
+  | {
+      status: "batch_error";
+      reason: MulticityBatchFetchErrorReason;
+    }
+  | {
+      status: "location_error";
+      errorCode: string | null;
+      detail: string | null;
+    }
+  | {
+      status: "missing_result";
+    }
+  | {
+      status: "ok";
+      currentRiskLevel: RiskLevel;
+      todayMaxRiskLevel: RiskLevel;
+    };
+
+const MULTICITY_CARD_ERROR_I18N_KEY_BY_CODE: Record<string, string> = {
+  weather_provider_unavailable: "errors.risk.weatherProvider",
+  unknown_inputs: "multicity.cardErrors.unknownInputs",
+  risk_calculation_failed: "multicity.cardErrors.riskCalculationFailed",
+};
+
+const MULTICITY_BATCH_ERROR_I18N_KEY_BY_REASON: Record<
+  MulticityBatchFetchErrorReason,
+  string
+> = {
+  missing_config: "errors.risk.missingApiBaseUrl",
+  abort: "errors.risk.network",
+  http_status: "errors.risk.network",
+  invalid_response: "errors.risk.invalidResponse",
+  network: "errors.risk.network",
+  weather_provider_unavailable: "errors.risk.weatherProvider",
+};
+
+/**
+ * Builds a stable React Query key segment from saved dashboard coordinates.
+ *
+ * Order is ignored so reordering cities does not refetch the same set.
+ */
+export function buildMulticityLocationCoordsKey(
+  locations: readonly Pick<SavedLocation, "latitude" | "longitude">[],
+): string {
+  return locations
+    .map((location) => toCoordinateKey(location.latitude, location.longitude))
+    .sort()
+    .join(";");
+}
+
+/**
+ * Indexes batch location results by normalized coordinate key.
+ */
+export function indexBatchResultsByCoordinateKey(
+  results: readonly BatchHeatRiskLocationResult[],
+): Map<string, BatchHeatRiskLocationResult> {
+  const indexedResults = new Map<string, BatchHeatRiskLocationResult>();
+
+  for (const result of results) {
+    indexedResults.set(
+      toCoordinateKey(result.latitude, result.longitude),
+      result,
+    );
+  }
+
+  return indexedResults;
+}
+
+/**
+ * Maps a per-location batch error code to an i18n key.
+ */
+export function toMulticityCardErrorI18nKey(errorCode: string | null): string {
+  if (errorCode && MULTICITY_CARD_ERROR_I18N_KEY_BY_CODE[errorCode]) {
+    return MULTICITY_CARD_ERROR_I18N_KEY_BY_CODE[errorCode];
+  }
+
+  return "multicity.cardErrors.generic";
+}
+
+/**
+ * Maps a whole-batch fetch failure reason to an i18n key.
+ */
+export function toMulticityBatchErrorI18nKey(
+  reason: MulticityBatchFetchErrorReason,
+): string {
+  return MULTICITY_BATCH_ERROR_I18N_KEY_BY_REASON[reason];
+}
+
+/**
+ * Resolves a saved location's card state from an indexed batch response.
+ */
+export function resolveMulticityCityCardState(
+  location: SavedLocation,
+  indexedResults: Map<string, BatchHeatRiskLocationResult> | null,
+  options?: { isFetching?: boolean },
+): MulticityCityCardState {
+  const isFetching = options?.isFetching === true;
+
+  if (!indexedResults) {
+    return { status: isFetching ? "loading" : "missing_result" };
+  }
+
+  const batchResult = indexedResults.get(
+    toCoordinateKey(location.latitude, location.longitude),
+  );
+
+  if (!batchResult) {
+    return { status: isFetching ? "loading" : "missing_result" };
+  }
+
+  if (batchResult.status === "error") {
+    return {
+      status: "location_error",
+      errorCode: batchResult.error_code,
+      detail: batchResult.detail,
+    };
+  }
+
+  const currentRisk = batchResult.current_risk_level_interpolated;
+  const todayMaxRisk = batchResult.today_max_risk_level_interpolated;
+
+  if (currentRisk === null || todayMaxRisk === null) {
+    return {
+      status: "location_error",
+      errorCode: "risk_calculation_failed",
+      detail: batchResult.detail,
+    };
+  }
+
+  return {
+    status: "ok",
+    currentRiskLevel: toRiskLevel(currentRisk),
+    todayMaxRiskLevel: toRiskLevel(todayMaxRisk),
+  };
+}

--- a/frontend/src/hooks/useHomeUrlSync.test.ts
+++ b/frontend/src/hooks/useHomeUrlSync.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isSharedNavigationInProgress } from "@/hooks/useHomeUrlSync";
+
+describe("isSharedNavigationInProgress", () => {
+  it("blocks URL sync while a shared location is still resolving", () => {
+    expect(
+      isSharedNavigationInProgress({
+        channel: "shared",
+        urlLocation: "Perth, Western Australia, Australia",
+        prefilledLocationResolveState: "pending",
+      }),
+    ).toBe(true);
+
+    expect(
+      isSharedNavigationInProgress({
+        channel: "shared",
+        urlLocation: "Perth, Western Australia, Australia",
+        prefilledLocationResolveState: "resolving",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows URL sync after a user selects a different city on a shared visit", () => {
+    expect(
+      isSharedNavigationInProgress({
+        channel: "shared",
+        urlLocation: "Perth, Western Australia, Australia",
+        prefilledLocationResolveState: "idle",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat direct visits as shared navigation", () => {
+    expect(
+      isSharedNavigationInProgress({
+        channel: "direct",
+        urlLocation: "Perth, Western Australia, Australia",
+        prefilledLocationResolveState: "pending",
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useHomeUrlSync.ts
+++ b/frontend/src/hooks/useHomeUrlSync.ts
@@ -1,12 +1,33 @@
 import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
 import type { HeatRiskProfile } from "@/domain/heatRiskProfile";
 import { savePersistedHomeFilters } from "@/pages/home/browserState";
 import type { SetQueryStates } from "@/pages/home/useHomeBootstrap";
+import { parseHomeSearchParams } from "@/pages/home/homeUrlState";
 import { useHomeStore } from "@/store/homeStore";
 
 interface UseHomeUrlSyncParams {
   setQueryStates: SetQueryStates;
   canSyncSelection: boolean;
+}
+
+export function isSharedNavigationInProgress(params: {
+  channel: ReturnType<typeof useHomeStore.getState>["channel"];
+  urlLocation: string | null;
+  prefilledLocationResolveState: ReturnType<
+    typeof useHomeStore.getState
+  >["prefilledLocationResolveState"];
+}): boolean {
+  const { channel, urlLocation, prefilledLocationResolveState } = params;
+
+  if (channel !== "shared" || !urlLocation) {
+    return false;
+  }
+
+  return (
+    prefilledLocationResolveState === "pending" ||
+    prefilledLocationResolveState === "resolving"
+  );
 }
 
 /**
@@ -16,19 +37,35 @@ export function useHomeUrlSync({
   setQueryStates,
   canSyncSelection,
 }: UseHomeUrlSyncParams): void {
+  const location = useLocation();
   const channel = useHomeStore((state) => state.channel);
   const profile = useHomeStore((state) => state.profile);
   const sport = useHomeStore((state) => state.sport);
   const selectedLocation = useHomeStore((state) => state.selectedLocation);
+  const prefilledLocationResolveState = useHomeStore(
+    (state) => state.prefilledLocationResolveState,
+  );
   const lastAppliedRef = useRef<{
     profile: HeatRiskProfile;
     sport: string;
     loc: string;
   } | null>(null);
   const syncRunRef = useRef(0);
+  const urlLocation =
+    parseHomeSearchParams(location.search).location?.trim() ?? "";
 
   useEffect(() => {
     if (!canSyncSelection || !selectedLocation) {
+      return;
+    }
+
+    if (
+      isSharedNavigationInProgress({
+        channel,
+        urlLocation: urlLocation || null,
+        prefilledLocationResolveState,
+      })
+    ) {
       return;
     }
 
@@ -72,9 +109,11 @@ export function useHomeUrlSync({
   }, [
     canSyncSelection,
     channel,
+    prefilledLocationResolveState,
     profile,
     selectedLocation,
     setQueryStates,
     sport,
+    urlLocation,
   ]);
 }

--- a/frontend/src/hooks/useMulticityHeatRisk.test.ts
+++ b/frontend/src/hooks/useMulticityHeatRisk.test.ts
@@ -1,0 +1,511 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BatchHeatRiskApiResponse } from "@/api/heatRiskBatch";
+import { DEFAULT_HEAT_RISK_PROFILE } from "@/domain/heatRiskProfile";
+import type { SavedLocation } from "@/domain/multicity";
+import { buildMulticityLocationCoordsKey } from "@/domain/multicityBatch";
+import { useMulticityHeatRisk } from "@/hooks/useMulticityHeatRisk";
+import { DEFAULT_SPORT_TYPE, SportType } from "@/domain/sport";
+import { ApiError } from "@/api/apiErrors";
+import { useMulticityStore } from "@/store/multicityStore";
+
+const { useQueryMock, fetchHeatRiskBatchMock, debouncedValueRef } = vi.hoisted(
+  () => ({
+    useQueryMock: vi.fn(),
+    fetchHeatRiskBatchMock: vi.fn(),
+    debouncedValueRef: { current: null as unknown },
+  }),
+);
+
+vi.mock("@tanstack/react-query", () => ({
+  keepPreviousData: <T>(value: T | undefined) => value,
+  useQuery: (options: unknown) => useQueryMock(options),
+}));
+
+vi.mock("@mantine/hooks", () => ({
+  useDebouncedValue: <T>(value: T) => [
+    (debouncedValueRef.current as T | null) ?? value,
+  ],
+}));
+
+vi.mock("@/api/heatRiskBatch", () => ({
+  fetchHeatRiskBatch: (...args: unknown[]) => fetchHeatRiskBatchMock(...args),
+}));
+
+vi.mock("@/store/multicityStore", async () => {
+  const actual = await vi.importActual<typeof import("@/store/multicityStore")>(
+    "@/store/multicityStore",
+  );
+  const realStore = actual.useMulticityStore;
+
+  const useMulticityStore = Object.assign(
+    <T>(selector: (state: ReturnType<typeof realStore.getState>) => T): T =>
+      selector(realStore.getState()),
+    {
+      getState: realStore.getState,
+      setState: realStore.setState,
+      subscribe: realStore.subscribe,
+    },
+  );
+
+  return { useMulticityStore };
+});
+
+const SYDNEY_LOCATION: SavedLocation = {
+  id: "location-sydney",
+  displayLabel: "Sydney, New South Wales, Australia",
+  name: "Sydney",
+  regionName: "New South Wales",
+  countryName: "Australia",
+  latitude: -33.847,
+  longitude: 151.067,
+  mapboxId: "mapbox-sydney",
+};
+
+const MELBOURNE_LOCATION: SavedLocation = {
+  id: "location-melbourne",
+  displayLabel: "Melbourne, Victoria, Australia",
+  name: "Melbourne",
+  regionName: "Victoria",
+  countryName: "Australia",
+  latitude: -37.813,
+  longitude: 144.963,
+  mapboxId: "mapbox-melbourne",
+};
+
+const BATCH_RESPONSE: BatchHeatRiskApiResponse = {
+  request: {
+    sport: SportType.Soccer,
+    profile: DEFAULT_HEAT_RISK_PROFILE,
+  },
+  locations: [
+    {
+      latitude: -33.847,
+      longitude: 151.067,
+      timezone: "Australia/Sydney",
+      status: "ok",
+      current_risk_level_interpolated: 1.94,
+      today_max_risk_level_interpolated: 2.14,
+      current_time_local: "2026-03-09T11:00:00+11:00",
+      error_code: null,
+      detail: null,
+    },
+    {
+      latitude: -37.813,
+      longitude: 144.963,
+      timezone: null,
+      status: "error",
+      current_risk_level_interpolated: null,
+      today_max_risk_level_interpolated: null,
+      current_time_local: null,
+      error_code: "weather_provider_unavailable",
+      detail: "Weather provider unavailable",
+    },
+  ],
+};
+
+function resetMulticityStore() {
+  useMulticityStore.setState({
+    isBootstrapped: true,
+    sport: DEFAULT_SPORT_TYPE,
+    locations: [],
+    locationSearchInput: "",
+    locationSessionToken: "session-initial",
+  });
+}
+
+function seedMulticityStore(
+  locations: SavedLocation[],
+  sport: (typeof SportType)[keyof typeof SportType] = DEFAULT_SPORT_TYPE,
+) {
+  useMulticityStore.getState().bootstrap({ sport, locations });
+}
+
+function invokeUseMulticityHeatRisk() {
+  let hookResult: ReturnType<typeof useMulticityHeatRisk> | undefined;
+
+  function Probe() {
+    // Static test probe: capture the hook result outside React state.
+    // eslint-disable-next-line react-hooks/globals -- test helper
+    hookResult = useMulticityHeatRisk();
+    return null;
+  }
+
+  renderToStaticMarkup(createElement(Probe));
+
+  if (!hookResult) {
+    throw new Error("useMulticityHeatRisk did not run");
+  }
+
+  return hookResult;
+}
+
+function getLatestUseQueryOptions(): {
+  queryKey: unknown[];
+  enabled: boolean;
+  queryFn: (context: { signal: AbortSignal }) => Promise<unknown>;
+  refetchInterval?: number;
+} {
+  const latestCall = useQueryMock.mock.calls.at(-1)?.[0];
+
+  if (!latestCall) {
+    throw new Error("useQuery was not called");
+  }
+
+  return latestCall as {
+    queryKey: unknown[];
+    enabled: boolean;
+    queryFn: (context: { signal: AbortSignal }) => Promise<unknown>;
+    refetchInterval?: number;
+  };
+}
+
+describe("useMulticityHeatRisk", () => {
+  beforeEach(() => {
+    resetMulticityStore();
+    debouncedValueRef.current = null;
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      error: null,
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+    fetchHeatRiskBatchMock.mockReset();
+  });
+
+  afterEach(() => {
+    resetMulticityStore();
+    debouncedValueRef.current = null;
+    useQueryMock.mockClear();
+    fetchHeatRiskBatchMock.mockClear();
+  });
+
+  it("disables the batch query when there are no saved locations", () => {
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(getLatestUseQueryOptions()).toMatchObject({
+      enabled: false,
+    });
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "missing_result",
+    });
+  });
+
+  it("enables the batch query with sport, profile, and coordinate key", () => {
+    seedMulticityStore(
+      [SYDNEY_LOCATION, MELBOURNE_LOCATION],
+      SportType.Running,
+    );
+
+    invokeUseMulticityHeatRisk();
+
+    expect(getLatestUseQueryOptions()).toMatchObject({
+      enabled: true,
+      queryKey: [
+        "heatRiskBatch",
+        SportType.Running,
+        DEFAULT_HEAT_RISK_PROFILE,
+        buildMulticityLocationCoordsKey([SYDNEY_LOCATION, MELBOURNE_LOCATION]),
+      ],
+    });
+    expect(getLatestUseQueryOptions().refetchInterval).toBeUndefined();
+  });
+
+  it("returns loading card state while the initial batch request is pending", () => {
+    seedMulticityStore([SYDNEY_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      error: null,
+      isPending: true,
+      isFetching: true,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.isFetching).toBe(true);
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "loading",
+    });
+  });
+
+  it("maps successful batch results to per-city card state", () => {
+    seedMulticityStore([SYDNEY_LOCATION, MELBOURNE_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: BATCH_RESPONSE,
+      error: null,
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "ok",
+      currentRiskLevel: "low",
+      todayMaxRiskLevel: "moderate",
+    });
+    expect(result.getCardState(MELBOURNE_LOCATION)).toEqual({
+      status: "location_error",
+      errorCode: "weather_provider_unavailable",
+      detail: "Weather provider unavailable",
+    });
+  });
+
+  it("returns batch_error card state when the initial request fails", () => {
+    seedMulticityStore([SYDNEY_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      error: new ApiError({
+        kind: "network",
+        message: "network",
+      }),
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "batch_error",
+      reason: "network",
+    });
+  });
+
+  it("keeps previous card data while a refetch is in flight", () => {
+    seedMulticityStore([SYDNEY_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: BATCH_RESPONSE,
+      error: null,
+      isPending: true,
+      isFetching: true,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "ok",
+      currentRiskLevel: "low",
+      todayMaxRiskLevel: "moderate",
+    });
+  });
+
+  it("shows loading for a newly added city while previous batch data is kept", () => {
+    seedMulticityStore([SYDNEY_LOCATION, MELBOURNE_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: {
+        ...BATCH_RESPONSE,
+        locations: [BATCH_RESPONSE.locations[0]],
+      },
+      error: null,
+      isPending: false,
+      isFetching: true,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "ok",
+      currentRiskLevel: "low",
+      todayMaxRiskLevel: "moderate",
+    });
+    expect(result.getCardState(MELBOURNE_LOCATION)).toEqual({
+      status: "loading",
+    });
+  });
+
+  it("shows loading for every card when placeholder data is for a different sport", () => {
+    seedMulticityStore(
+      [SYDNEY_LOCATION, MELBOURNE_LOCATION],
+      SportType.Running,
+    );
+    useQueryMock.mockReturnValue({
+      data: BATCH_RESPONSE,
+      error: null,
+      isPending: false,
+      isFetching: true,
+      isPlaceholderData: true,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "loading",
+    });
+    expect(result.getCardState(MELBOURNE_LOCATION)).toEqual({
+      status: "loading",
+    });
+  });
+
+  it("keeps same-sport placeholder data for existing cities when a city is added", () => {
+    seedMulticityStore([SYDNEY_LOCATION, MELBOURNE_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: {
+        ...BATCH_RESPONSE,
+        locations: [BATCH_RESPONSE.locations[0]],
+      },
+      error: null,
+      isPending: false,
+      isFetching: true,
+      isPlaceholderData: true,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "ok",
+      currentRiskLevel: "low",
+      todayMaxRiskLevel: "moderate",
+    });
+    expect(result.getCardState(MELBOURNE_LOCATION)).toEqual({
+      status: "loading",
+    });
+  });
+
+  it("shows loading while the displayed sport is ahead of the debounced query sport", () => {
+    seedMulticityStore([SYDNEY_LOCATION], SportType.Running);
+    debouncedValueRef.current = SportType.Soccer;
+    useQueryMock.mockReturnValue({
+      data: BATCH_RESPONSE,
+      error: null,
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const result = invokeUseMulticityHeatRisk();
+
+    expect(result.getCardState(SYDNEY_LOCATION)).toEqual({
+      status: "loading",
+    });
+  });
+
+  it("keeps the same query key when saved locations are reordered", () => {
+    seedMulticityStore([SYDNEY_LOCATION, MELBOURNE_LOCATION]);
+    invokeUseMulticityHeatRisk();
+    const initialQueryKey = getLatestUseQueryOptions().queryKey;
+
+    seedMulticityStore([MELBOURNE_LOCATION, SYDNEY_LOCATION]);
+    invokeUseMulticityHeatRisk();
+
+    expect(getLatestUseQueryOptions().queryKey).toEqual(initialQueryKey);
+  });
+
+  it("calls fetchHeatRiskBatch with the debounced sport and saved coordinates", async () => {
+    seedMulticityStore([SYDNEY_LOCATION], SportType.Cricket);
+    fetchHeatRiskBatchMock.mockResolvedValue({
+      ok: true,
+      data: BATCH_RESPONSE,
+    });
+
+    invokeUseMulticityHeatRisk();
+
+    const { queryFn } = getLatestUseQueryOptions();
+    const controller = new AbortController();
+
+    await queryFn({ signal: controller.signal });
+
+    expect(fetchHeatRiskBatchMock).toHaveBeenCalledWith(
+      {
+        sport: SportType.Cricket,
+        profile: DEFAULT_HEAT_RISK_PROFILE,
+        locations: [
+          {
+            latitude: SYDNEY_LOCATION.latitude,
+            longitude: SYDNEY_LOCATION.longitude,
+          },
+        ],
+      },
+      { signal: controller.signal },
+    );
+  });
+
+  it("reconfigures the query key when the multicity sport changes", () => {
+    seedMulticityStore([SYDNEY_LOCATION], SportType.Soccer);
+
+    invokeUseMulticityHeatRisk();
+    const initialQueryKey = getLatestUseQueryOptions().queryKey;
+
+    useMulticityStore.getState().setSport(SportType.Running);
+    invokeUseMulticityHeatRisk();
+    const nextQueryKey = getLatestUseQueryOptions().queryKey;
+
+    expect(initialQueryKey).not.toEqual(nextQueryKey);
+    expect(nextQueryKey[1]).toBe(SportType.Running);
+  });
+
+  it("reports a loaded batch only after the first successful response", () => {
+    seedMulticityStore([SYDNEY_LOCATION]);
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      error: null,
+      isPending: true,
+      isFetching: true,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    expect(invokeUseMulticityHeatRisk().hasLoadedBatch).toBe(false);
+
+    useQueryMock.mockReturnValue({
+      data: BATCH_RESPONSE,
+      error: null,
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    expect(invokeUseMulticityHeatRisk().hasLoadedBatch).toBe(true);
+  });
+
+  it("refetches the batch query and reports success", async () => {
+    seedMulticityStore([SYDNEY_LOCATION]);
+    const refetch = vi.fn().mockResolvedValue({ isError: false });
+    useQueryMock.mockReturnValue({
+      data: BATCH_RESPONSE,
+      error: null,
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch,
+    });
+
+    const didRefresh = await invokeUseMulticityHeatRisk().refresh();
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(didRefresh).toBe(true);
+  });
+
+  it("does not refetch when there are no saved locations", async () => {
+    const refetch = vi.fn().mockResolvedValue({ isError: false });
+    useQueryMock.mockReturnValue({
+      data: undefined,
+      error: null,
+      isPending: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      refetch,
+    });
+
+    const didRefresh = await invokeUseMulticityHeatRisk().refresh();
+
+    expect(refetch).not.toHaveBeenCalled();
+    expect(didRefresh).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useMulticityHeatRisk.ts
+++ b/frontend/src/hooks/useMulticityHeatRisk.ts
@@ -1,0 +1,150 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "@mantine/hooks";
+import { useMemo } from "react";
+import { ApiError, isApiError } from "@/api/apiErrors";
+import { getRetryDelayMs, heatRiskRetryPolicy } from "@/api/apiRetryPolicy";
+import { fetchHeatRiskBatch } from "@/api/heatRiskBatch";
+import { DEFAULT_HEAT_RISK_PROFILE } from "@/domain/heatRiskProfile";
+import type { SavedLocation } from "@/domain/multicity";
+import {
+  buildMulticityLocationCoordsKey,
+  indexBatchResultsByCoordinateKey,
+  resolveMulticityCityCardState,
+  type MulticityBatchFetchErrorReason,
+  type MulticityCityCardState,
+} from "@/domain/multicityBatch";
+import { useMulticityStore } from "@/store/multicityStore";
+
+interface UseMulticityHeatRiskResult {
+  getCardState: (location: SavedLocation) => MulticityCityCardState;
+  isFetching: boolean;
+  hasLoadedBatch: boolean;
+  refresh: () => Promise<boolean>;
+}
+
+function toMulticityBatchFetchErrorReason(
+  error: unknown,
+): MulticityBatchFetchErrorReason | null {
+  if (!isApiError(error)) {
+    return null;
+  }
+
+  return error.serverCode === "weather_provider_unavailable"
+    ? "weather_provider_unavailable"
+    : error.kind;
+}
+
+/**
+ * Fetches batch heat-risk summaries for all saved multi-city locations.
+ */
+export function useMulticityHeatRisk(): UseMulticityHeatRiskResult {
+  const sport = useMulticityStore((state) => state.sport);
+  const locations = useMulticityStore((state) => state.locations);
+  const [debouncedSport] = useDebouncedValue(sport, 250);
+  const profile = DEFAULT_HEAT_RISK_PROFILE;
+
+  const requestLocations = useMemo(
+    () =>
+      locations.map((location) => ({
+        latitude: location.latitude,
+        longitude: location.longitude,
+      })),
+    [locations],
+  );
+
+  const locationCoordsKey = buildMulticityLocationCoordsKey(locations);
+
+  const batchQuery = useQuery({
+    queryKey: ["heatRiskBatch", debouncedSport, profile, locationCoordsKey],
+    queryFn: async ({ signal }) => {
+      const result = await fetchHeatRiskBatch(
+        {
+          sport: debouncedSport,
+          profile,
+          locations: requestLocations,
+        },
+        { signal },
+      );
+
+      if (!result.ok) {
+        throw new ApiError({
+          kind:
+            result.reason === "weather_provider_unavailable"
+              ? "http_status"
+              : result.reason,
+          status: result.status,
+          serverCode:
+            result.reason === "weather_provider_unavailable"
+              ? "weather_provider_unavailable"
+              : undefined,
+          message: result.reason,
+        });
+      }
+
+      return result.data;
+    },
+    enabled: locations.length > 0,
+    placeholderData: keepPreviousData,
+    retry: (failureCount, error) =>
+      failureCount < heatRiskRetryPolicy.maxRetries &&
+      heatRiskRetryPolicy.shouldRetry(error),
+    retryDelay: () => getRetryDelayMs({ scope: "heat_risk" }),
+    staleTime: 0,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const indexedResults = useMemo(
+    () =>
+      batchQuery.data
+        ? indexBatchResultsByCoordinateKey(batchQuery.data.locations)
+        : null,
+    [batchQuery.data],
+  );
+
+  const batchErrorReason = toMulticityBatchFetchErrorReason(batchQuery.error);
+  const isInitialLoading = batchQuery.isPending && !batchQuery.data;
+  const isDisplayedSportPending =
+    sport !== debouncedSport ||
+    (batchQuery.data != null && batchQuery.data.request.sport !== sport);
+  const hasLoadedBatch = Boolean(
+    locations.length > 0 &&
+    batchQuery.data &&
+    !batchQuery.isPlaceholderData &&
+    sport === debouncedSport,
+  );
+
+  async function refresh(): Promise<boolean> {
+    if (locations.length === 0 || sport !== debouncedSport) {
+      return false;
+    }
+
+    const result = await batchQuery.refetch();
+
+    return !result.isError;
+  }
+
+  function getCardState(location: SavedLocation): MulticityCityCardState {
+    if (isInitialLoading || isDisplayedSportPending) {
+      return { status: "loading" };
+    }
+
+    if (batchErrorReason && !batchQuery.data) {
+      return {
+        status: "batch_error",
+        reason: batchErrorReason,
+      };
+    }
+
+    return resolveMulticityCityCardState(location, indexedResults, {
+      isFetching: batchQuery.isFetching,
+    });
+  }
+
+  return {
+    getCardState,
+    isFetching: batchQuery.isFetching,
+    hasLoadedBatch,
+    refresh,
+  };
+}

--- a/frontend/src/hooks/useMulticityLocationAdd.ts
+++ b/frontend/src/hooks/useMulticityLocationAdd.ts
@@ -1,0 +1,238 @@
+import { useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "@mantine/hooks";
+import { useEffect, useMemo, useState } from "react";
+import { suggestLocations } from "@/api/mapboxSuggest";
+import type { LocationSuggestion } from "@/domain/location";
+import {
+  LOCATION_SUGGEST_TYPES_PARAM,
+  prepareLocationSuggestions,
+} from "@/domain/locationSearch";
+import { retrieveAndSelectLocation } from "@/hooks/homeLocationRetrieve";
+import { createLatestAbortableRequestController } from "@/lib/latestAbortableRequest";
+import {
+  MAX_SAVED_LOCATIONS,
+  type AddLocationFailureReason,
+} from "@/domain/multicity";
+import { useMulticityStore } from "@/store/multicityStore";
+
+const MIN_LOCATION_QUERY_LENGTH = 2;
+const SUGGEST_DEBOUNCE_MS = 800;
+const EMPTY_SUGGESTIONS: LocationSuggestion[] = [];
+
+export type MulticityLocationAddErrorReason =
+  | "missing_token"
+  | "retrieve_failed"
+  | "unavailable"
+  | "no_results"
+  | AddLocationFailureReason;
+
+interface UseMulticityLocationAddResult {
+  locationSearchInput: string;
+  locationSuggestions: LocationSuggestion[];
+  isSuggestLoading: boolean;
+  isAddingLocation: boolean;
+  canAddMoreLocations: boolean;
+  addErrorReason: MulticityLocationAddErrorReason | null;
+  onLocationSearchInputChange: (value: string) => void;
+  onLocationOptionSubmit: (suggestionId: string) => void;
+}
+
+function getLanguagePreference(): string | undefined {
+  if (typeof navigator === "undefined") {
+    return undefined;
+  }
+
+  if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
+    return navigator.languages.join(",");
+  }
+
+  return navigator.language || undefined;
+}
+
+function findSubmittedSuggestion(
+  suggestions: LocationSuggestion[],
+  suggestionId: string,
+): LocationSuggestion | null {
+  return (
+    suggestions.find((suggestion) => suggestion.id === suggestionId) ?? null
+  );
+}
+
+/**
+ * Location suggest and add flow for the multi-city dashboard.
+ */
+export function useMulticityLocationAdd(): UseMulticityLocationAddResult {
+  const mapboxAccessToken = (
+    import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? ""
+  ).trim();
+  const hasMapboxToken = mapboxAccessToken.length > 0;
+  const locationSearchInput = useMulticityStore(
+    (state) => state.locationSearchInput,
+  );
+  const sessionToken = useMulticityStore((state) => state.locationSessionToken);
+  const locations = useMulticityStore((state) => state.locations);
+  const setLocationSearchInput = useMulticityStore(
+    (state) => state.setLocationSearchInput,
+  );
+  const addLocation = useMulticityStore((state) => state.addLocation);
+  const [hasRetrieveError, setHasRetrieveError] = useState(false);
+  const [isAddingLocation, setIsAddingLocation] = useState(false);
+  const [addErrorReason, setAddErrorReason] =
+    useState<MulticityLocationAddErrorReason | null>(null);
+  const retrieveController = useMemo(
+    () => createLatestAbortableRequestController(),
+    [],
+  );
+
+  const query = locationSearchInput.trim();
+  const language = useMemo(() => getLanguagePreference(), []);
+  const [debouncedQuery] = useDebouncedValue(query, SUGGEST_DEBOUNCE_MS);
+  const debouncedQueryValue = debouncedQuery.trim();
+  const hasDebounced = debouncedQueryValue === query;
+  const canAddMoreLocations = locations.length < MAX_SAVED_LOCATIONS;
+
+  const shouldSuggest =
+    hasMapboxToken &&
+    hasDebounced &&
+    debouncedQueryValue.length >= MIN_LOCATION_QUERY_LENGTH &&
+    canAddMoreLocations;
+
+  const suggestQuery = useQuery({
+    queryKey: [
+      "mapboxSuggest",
+      "multicity",
+      debouncedQueryValue,
+      sessionToken,
+      language,
+      LOCATION_SUGGEST_TYPES_PARAM,
+    ],
+    queryFn: async ({ signal }) => {
+      const suggestions = await suggestLocations({
+        query: debouncedQueryValue,
+        accessToken: mapboxAccessToken,
+        sessionToken,
+        signal,
+        language,
+        types: LOCATION_SUGGEST_TYPES_PARAM,
+      });
+
+      return prepareLocationSuggestions({
+        suggestions,
+      });
+    },
+    enabled: shouldSuggest,
+    retry: false,
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const dedupedSuggestions =
+    suggestQuery.data?.dedupedSuggestions ?? EMPTY_SUGGESTIONS;
+  const visibleSuggestions =
+    suggestQuery.data?.visibleSuggestions ?? EMPTY_SUGGESTIONS;
+
+  useEffect(() => () => retrieveController.cancel(), [retrieveController]);
+
+  const resolveSuggestErrorReason =
+    (): MulticityLocationAddErrorReason | null => {
+      if (!hasMapboxToken) {
+        return "missing_token";
+      }
+
+      if (hasRetrieveError) {
+        return "retrieve_failed";
+      }
+
+      if (!shouldSuggest) {
+        return null;
+      }
+
+      if (suggestQuery.isError) {
+        return "unavailable";
+      }
+
+      if (suggestQuery.isSuccess && dedupedSuggestions.length === 0) {
+        return "no_results";
+      }
+
+      return null;
+    };
+
+  const addResolvedSuggestion = async (
+    selectedSuggestion: LocationSuggestion,
+  ) => {
+    setIsAddingLocation(true);
+    setAddErrorReason(null);
+
+    const mapboxId = selectedSuggestion.mapboxId;
+    const suggestionSessionToken = selectedSuggestion.sessionToken;
+
+    if (!mapboxId || !suggestionSessionToken || !hasMapboxToken) {
+      setHasRetrieveError(true);
+      setIsAddingLocation(false);
+      return;
+    }
+
+    const request = retrieveController.start();
+
+    try {
+      await retrieveAndSelectLocation({
+        selectedSuggestion,
+        hasMapboxToken,
+        mapboxAccessToken,
+        request,
+        selectLocation: (resolvedSuggestion) => {
+          const result = addLocation(resolvedSuggestion);
+          if (!result.ok) {
+            setAddErrorReason(result.reason);
+            return;
+          }
+
+          setAddErrorReason(null);
+        },
+        setHasRetrieveError,
+      });
+    } finally {
+      setIsAddingLocation(false);
+    }
+  };
+
+  const onLocationSearchInputChange = (value: string) => {
+    retrieveController.cancel();
+
+    if (hasRetrieveError) {
+      setHasRetrieveError(false);
+    }
+
+    if (addErrorReason) {
+      setAddErrorReason(null);
+    }
+
+    setLocationSearchInput(value);
+  };
+
+  const onLocationOptionSubmit = (suggestionId: string) => {
+    const selectedSuggestion = findSubmittedSuggestion(
+      dedupedSuggestions,
+      suggestionId,
+    );
+
+    if (!selectedSuggestion) {
+      return;
+    }
+
+    void addResolvedSuggestion(selectedSuggestion);
+  };
+
+  return {
+    locationSearchInput,
+    locationSuggestions: visibleSuggestions,
+    isSuggestLoading: shouldSuggest && suggestQuery.isFetching,
+    isAddingLocation,
+    canAddMoreLocations,
+    addErrorReason: addErrorReason ?? resolveSuggestErrorReason(),
+    onLocationSearchInputChange,
+    onLocationOptionSubmit,
+  };
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -4,6 +4,7 @@
   },
   "nav": {
     "home": "Home",
+    "multicityDashboard": "Multi-city dashboard",
     "about": "About",
     "detailedRecommendations": "Recommendations",
     "drawerTitle": "Navigation",
@@ -444,6 +445,50 @@
           "Active cooling strategies should be applied."
         ]
       }
+    }
+  },
+  "multicity": {
+    "notifications": {
+      "riskUpdated": "Risk updated"
+    },
+    "header": {
+      "title": "Multi-city dashboard view",
+      "subtitlePrefix": "Compare heat risk ratings across multiple cities for",
+      "sportLabel": "Sport",
+      "sportNotFound": "No sports found"
+    },
+    "addLocation": {
+      "title": "Search to add a location",
+      "inputLabel": "Location",
+      "placeholder": "Location"
+    },
+    "emptyState": {
+      "title": "No saved locations yet",
+      "body": "Search for a city and add it to start monitoring heat risk across multiple locations."
+    },
+    "cards": {
+      "openHomeAriaLabel": "Open {{city}} on the home page",
+      "menuAriaLabel": "City actions",
+      "delete": "Delete",
+      "moveUp": "Move up",
+      "moveDown": "Move down",
+      "moveLeft": "Move left",
+      "moveRight": "Move right"
+    },
+    "cardErrors": {
+      "generic": "Risk data could not be loaded for this location.",
+      "missingResult": "Risk data is unavailable for this location.",
+      "unknownInputs": "Weather inputs are unavailable for this location.",
+      "riskCalculationFailed": "Risk could not be calculated for this location."
+    },
+    "errors": {
+      "missing_token": "Location search is unavailable because Mapbox is not configured.",
+      "retrieve_failed": "Could not resolve the selected location. Please try again.",
+      "unavailable": "Location search is temporarily unavailable. Please try again.",
+      "no_results": "No locations matched your search.",
+      "duplicate": "This location is already saved.",
+      "max_reached": "You can save up to 6 locations.",
+      "missing_coordinates": "The selected location could not be resolved."
     }
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/translation.json
+++ b/frontend/src/i18n/locales/zh-CN/translation.json
@@ -4,6 +4,7 @@
   },
   "nav": {
     "home": "首页",
+    "multicityDashboard": "多城市看板",
     "about": "关于",
     "detailedRecommendations": "建议",
     "drawerTitle": "导航",
@@ -439,6 +440,50 @@
           "应采取主动降温措施。"
         ]
       }
+    }
+  },
+  "multicity": {
+    "notifications": {
+      "riskUpdated": "风险已更新"
+    },
+    "header": {
+      "title": "多城市看板",
+      "subtitlePrefix": "比较多个城市在以下运动项目中的热应激风险：",
+      "sportLabel": "运动项目",
+      "sportNotFound": "未找到运动项目"
+    },
+    "addLocation": {
+      "title": "搜索并添加地点",
+      "inputLabel": "地点",
+      "placeholder": "地点"
+    },
+    "emptyState": {
+      "title": "尚未保存地点",
+      "body": "搜索并添加城市，即可开始对比多个地点的热应激风险。"
+    },
+    "cards": {
+      "openHomeAriaLabel": "在首页打开 {{city}}",
+      "menuAriaLabel": "城市操作",
+      "delete": "删除",
+      "moveUp": "上移",
+      "moveDown": "下移",
+      "moveLeft": "左移",
+      "moveRight": "右移"
+    },
+    "cardErrors": {
+      "generic": "无法加载此地点的风险数据。",
+      "missingResult": "此地点暂无风险数据。",
+      "unknownInputs": "此地点的天气输入不可用。",
+      "riskCalculationFailed": "无法计算此地点的风险。"
+    },
+    "errors": {
+      "missing_token": "地点搜索不可用，因为尚未配置 Mapbox。",
+      "retrieve_failed": "无法解析所选地点，请重试。",
+      "unavailable": "地点搜索暂时不可用，请重试。",
+      "no_results": "没有与搜索匹配的地点。",
+      "duplicate": "此地点已保存。",
+      "max_reached": "最多可保存 6 个地点。",
+      "missing_coordinates": "无法解析所选地点。"
     }
   }
 }

--- a/frontend/src/pages/MultiCityPage.tsx
+++ b/frontend/src/pages/MultiCityPage.tsx
@@ -1,0 +1,123 @@
+import { Stack } from "@mantine/core";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { CityCardList } from "@/components/multicity/CityCardList";
+import { MultiCityMainPanel } from "@/components/multicity/MultiCityMainPanel";
+import { BottomToast } from "@/components/ui/BottomToast";
+import { SECTION_STACK_GAP } from "@/config/uiLayout";
+import type { MulticityLocationAddErrorReason } from "@/hooks/useMulticityLocationAdd";
+import { useMulticityBootstrap } from "@/pages/multicity/useMulticityBootstrap";
+import {
+  createMulticityRiskUpdatedToast,
+  type MulticityToastEvent,
+} from "@/pages/multicity/multicityToast";
+import { useMulticityHeatRisk } from "@/hooks/useMulticityHeatRisk";
+import { useMulticityStore } from "@/store/multicityStore";
+
+const MULTICITY_AUTO_REFRESH_INTERVAL_MS = 20 * 60 * 1000;
+
+function toMulticityAddErrorMessageKey(
+  reason: MulticityLocationAddErrorReason,
+): `multicity.errors.${MulticityLocationAddErrorReason}` {
+  return `multicity.errors.${reason}`;
+}
+
+/**
+ * Renders the multi-city dashboard page.
+ */
+export function MultiCityPage() {
+  const { t } = useTranslation();
+  useMulticityBootstrap();
+  const locations = useMulticityStore((state) => state.locations);
+  const sport = useMulticityStore((state) => state.sport);
+  const heatRisk = useMulticityHeatRisk();
+  const [toastEvent, setToastEvent] = useState<MulticityToastEvent | null>(
+    null,
+  );
+  const nextToastEventIdRef = useRef(0);
+
+  const publishToast = useCallback(
+    (createToast: (id: number) => MulticityToastEvent) => {
+      const nextToastEventId = nextToastEventIdRef.current + 1;
+      nextToastEventIdRef.current = nextToastEventId;
+      setToastEvent(createToast(nextToastEventId));
+    },
+    [],
+  );
+
+  const handleAddError = useCallback(
+    (reason: MulticityLocationAddErrorReason) => {
+      publishToast((id) => ({
+        id,
+        i18nKey: toMulticityAddErrorMessageKey(reason),
+        variant: "error",
+      }));
+    },
+    [publishToast],
+  );
+  const runScheduledRefresh = useEffectEvent(async () => heatRisk.refresh());
+
+  useEffect(() => {
+    if (!(locations.length > 0 && heatRisk.hasLoadedBatch)) {
+      return;
+    }
+
+    let timeoutId: number | null = null;
+    let isCancelled = false;
+
+    const scheduleNextRefresh = () => {
+      timeoutId = window.setTimeout(async () => {
+        const didRefresh = await runScheduledRefresh();
+
+        if (isCancelled) {
+          return;
+        }
+
+        if (didRefresh) {
+          publishToast(createMulticityRiskUpdatedToast);
+        }
+
+        scheduleNextRefresh();
+      }, MULTICITY_AUTO_REFRESH_INTERVAL_MS);
+    };
+
+    scheduleNextRefresh();
+
+    return () => {
+      isCancelled = true;
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [heatRisk.hasLoadedBatch, locations, publishToast, sport]);
+
+  return (
+    <>
+      <Stack gap={SECTION_STACK_GAP}>
+        <MultiCityMainPanel onAddError={handleAddError} />
+        {locations.length > 0 ? (
+          <CityCardList
+            locations={locations}
+            getCardState={heatRisk.getCardState}
+          />
+        ) : null}
+      </Stack>
+
+      {toastEvent ? (
+        <BottomToast
+          eventId={toastEvent.id}
+          message={t(toastEvent.i18nKey)}
+          variant={toastEvent.variant}
+          durationMs={toastEvent.durationMs}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/pages/home/homeUrlState.test.ts
+++ b/frontend/src/pages/home/homeUrlState.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { SportType } from "@/domain/sport";
+import {
+  hasHomeSearchParams,
+  parseHomeSearchParams,
+} from "@/pages/home/homeUrlState";
+
+describe("homeUrlState", () => {
+  it("parses shared home navigation query params from the location search", () => {
+    expect(
+      parseHomeSearchParams(
+        "?sport=SOCCER&loc=Sydney%2C+New+South+Wales%2C+Australia",
+      ),
+    ).toEqual({
+      profile: null,
+      sport: SportType.Soccer,
+      location: "Sydney, New South Wales, Australia",
+    });
+  });
+
+  it("detects when home filter params are present", () => {
+    expect(hasHomeSearchParams("?sport=SOCCER")).toBe(true);
+    expect(hasHomeSearchParams("")).toBe(false);
+  });
+});

--- a/frontend/src/pages/home/homeUrlState.ts
+++ b/frontend/src/pages/home/homeUrlState.ts
@@ -1,9 +1,10 @@
 import { parseAsString, parseAsStringEnum } from "nuqs";
 import {
   HEAT_RISK_PROFILE_VALUES,
+  isHeatRiskProfile,
   type HeatRiskProfile,
 } from "@/domain/heatRiskProfile";
-import { SPORT_TYPE_VALUES } from "@/domain/sport";
+import { isSportType, SPORT_TYPE_VALUES, type SportType } from "@/domain/sport";
 
 export const VALID_PROFILE_VALUES: HeatRiskProfile[] = [
   ...HEAT_RISK_PROFILE_VALUES,
@@ -19,3 +20,43 @@ export const HOME_QUERY_PARSERS = {
 export const HOME_QUERY_URL_KEYS = {
   location: "loc",
 } as const;
+
+export interface ParsedHomeSearchParams {
+  profile: HeatRiskProfile | null;
+  sport: SportType | null;
+  location: string | null;
+}
+
+/**
+ * Parses Home URL search params directly from the browser location string.
+ */
+export function parseHomeSearchParams(search: string): ParsedHomeSearchParams {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search,
+  );
+  const profileValue = params.get("profile");
+  const sportValue = params.get("sport");
+  const locationValue = params.get(HOME_QUERY_URL_KEYS.location);
+
+  return {
+    profile:
+      profileValue && isHeatRiskProfile(profileValue) ? profileValue : null,
+    sport: sportValue && isSportType(sportValue) ? sportValue : null,
+    location: locationValue,
+  };
+}
+
+/**
+ * Returns whether the search string includes any Home filter query params.
+ */
+export function hasHomeSearchParams(search: string): boolean {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search,
+  );
+
+  return (
+    params.has("profile") ||
+    params.has("sport") ||
+    params.has(HOME_QUERY_URL_KEYS.location)
+  );
+}

--- a/frontend/src/pages/home/useHomeBootstrap.ts
+++ b/frontend/src/pages/home/useHomeBootstrap.ts
@@ -1,7 +1,7 @@
 import { useQueryStates } from "nuqs";
-import { useOptimisticSearchParams } from "nuqs/adapters/react-router/v7";
-import { useEffect, useMemo } from "react";
+import { useLayoutEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 import {
   DEFAULT_HEAT_RISK_PROFILE,
   type HeatRiskProfile,
@@ -13,8 +13,10 @@ import {
 } from "@/pages/home/browserState";
 import { resolveHomeBootstrapState } from "@/pages/home/homeBootstrap";
 import {
+  hasHomeSearchParams,
   HOME_QUERY_PARSERS,
   HOME_QUERY_URL_KEYS,
+  parseHomeSearchParams,
   VALID_PROFILE_VALUES,
   VALID_SPORT_VALUES,
 } from "@/pages/home/homeUrlState";
@@ -45,18 +47,17 @@ interface UseHomeBootstrapResult {
  */
 export function useHomeBootstrap(): UseHomeBootstrapResult {
   const { t } = useTranslation();
-  const optimisticSearchParams = useOptimisticSearchParams();
-  const [
-    { profile: urlProfile, sport: urlSport, location: urlLocation },
-    setQueryStates,
-  ] = useQueryStates(HOME_QUERY_PARSERS, {
+  const location = useLocation();
+  const [, setQueryStates] = useQueryStates(HOME_QUERY_PARSERS, {
     urlKeys: HOME_QUERY_URL_KEYS,
   });
 
-  const hasUrlState =
-    optimisticSearchParams.has("profile") ||
-    optimisticSearchParams.has("sport") ||
-    optimisticSearchParams.has("loc");
+  const parsedUrlState = useMemo(
+    () => parseHomeSearchParams(location.search),
+    [location.search],
+  );
+
+  const hasUrlState = hasHomeSearchParams(location.search);
   const persistedFilters = useMemo(
     () =>
       hasUrlState
@@ -72,23 +73,37 @@ export function useHomeBootstrap(): UseHomeBootstrapResult {
         defaultProfile: DEFAULT_HEAT_RISK_PROFILE,
         defaultSport: DEFAULT_SPORT_TYPE,
         defaultLocationLabel: t("home.sections.filters.defaultLocation"),
-        urlProfile,
-        urlSport,
-        urlLocation,
+        urlProfile: parsedUrlState.profile,
+        urlSport: parsedUrlState.sport,
+        urlLocation: parsedUrlState.location,
         persistedFilters,
       }),
-    [hasUrlState, persistedFilters, t, urlLocation, urlProfile, urlSport],
+    [
+      hasUrlState,
+      parsedUrlState.location,
+      parsedUrlState.profile,
+      parsedUrlState.sport,
+      persistedFilters,
+      t,
+    ],
   );
 
-  useEffect(() => {
-    if (useHomeStore.getState().isBootstrapped) {
+  useLayoutEffect(() => {
+    const store = useHomeStore.getState();
+
+    if (!store.isBootstrapped) {
+      store.bootstrap(bootstrapState);
       return;
     }
 
-    useHomeStore.getState().bootstrap(bootstrapState);
-  }, [bootstrapState]);
+    if (!hasUrlState) {
+      return;
+    }
 
-  useEffect(() => {
+    store.applySharedUrlNavigation(bootstrapState);
+  }, [bootstrapState, hasUrlState]);
+
+  useLayoutEffect(() => {
     useHomeUiStore
       .getState()
       .setShowWeatherDetails(loadPersistedShowWeatherDetails());

--- a/frontend/src/pages/multicity/browserState.test.ts
+++ b/frontend/src/pages/multicity/browserState.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_SAVED_LOCATIONS } from "@/domain/multicity";
+import { SportType, SPORT_TYPE_VALUES } from "@/domain/sport";
+import {
+  loadPersistedMulticityState,
+  resolveInitialMulticityLocations,
+  resolveInitialMulticitySport,
+  savePersistedMulticityState,
+} from "@/pages/multicity/browserState";
+
+const MULTICITY_STORAGE_KEY = "multicity-locations:v1";
+
+interface LocalStorageMock {
+  clear: () => void;
+  getItem: (key: string) => string | null;
+  removeItem: (key: string) => void;
+  setItem: (key: string, value: string) => void;
+}
+
+function installWindowMock(): Map<string, string> {
+  const storage = new Map<string, string>();
+  const localStorage: LocalStorageMock = {
+    clear: () => storage.clear(),
+    getItem: (key) => storage.get(key) ?? null,
+    removeItem: (key) => {
+      storage.delete(key);
+    },
+    setItem: (key, value) => {
+      storage.set(key, value);
+    },
+  };
+
+  vi.stubGlobal("window", {
+    localStorage,
+  });
+
+  return storage;
+}
+
+describe("multicity browserState", () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = installWindowMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads persisted dashboard state", () => {
+    storage.set(
+      MULTICITY_STORAGE_KEY,
+      JSON.stringify({
+        sport: SportType.Soccer,
+        locations: [
+          {
+            id: "location-1",
+            displayLabel: "Sydney, New South Wales, Australia",
+            name: "Sydney",
+            regionName: "New South Wales",
+            countryName: "Australia",
+            latitude: -33.847,
+            longitude: 151.067,
+          },
+        ],
+      }),
+    );
+
+    expect(loadPersistedMulticityState(SPORT_TYPE_VALUES)).toEqual({
+      sport: SportType.Soccer,
+      locations: [
+        {
+          id: "location-1",
+          displayLabel: "Sydney, New South Wales, Australia",
+          name: "Sydney",
+          regionName: "New South Wales",
+          countryName: "Australia",
+          latitude: -33.847,
+          longitude: 151.067,
+        },
+      ],
+    });
+  });
+
+  it("defaults to an empty location list when nothing is persisted", () => {
+    expect(resolveInitialMulticityLocations(null)).toEqual([]);
+    expect(resolveInitialMulticitySport(null)).toBe(SportType.Soccer);
+  });
+
+  it("keeps saved locations when the persisted sport is invalid", () => {
+    storage.set(
+      MULTICITY_STORAGE_KEY,
+      JSON.stringify({
+        sport: "NOT_A_SPORT",
+        locations: [
+          {
+            id: "location-1",
+            displayLabel: "Sydney, New South Wales, Australia",
+            name: "Sydney",
+            countryName: "Australia",
+            latitude: -33.847,
+            longitude: 151.067,
+          },
+        ],
+      }),
+    );
+
+    const persistedState = loadPersistedMulticityState(SPORT_TYPE_VALUES);
+
+    expect(persistedState?.sport).toBe(SportType.Soccer);
+    expect(persistedState?.locations).toHaveLength(1);
+    expect(persistedState?.locations[0]?.name).toBe("Sydney");
+  });
+
+  it("caps persisted locations at the dashboard maximum", () => {
+    const locations = Array.from(
+      { length: MAX_SAVED_LOCATIONS + 1 },
+      (_, index) => ({
+        id: `location-${index}`,
+        displayLabel: `City ${index}`,
+        name: `City ${index}`,
+        countryName: "Australia",
+        latitude: -33 + index * 0.01,
+        longitude: 151 + index * 0.01,
+      }),
+    );
+
+    storage.set(
+      MULTICITY_STORAGE_KEY,
+      JSON.stringify({
+        sport: SportType.Soccer,
+        locations,
+      }),
+    );
+
+    const persistedState = loadPersistedMulticityState(SPORT_TYPE_VALUES);
+
+    expect(persistedState?.locations).toHaveLength(MAX_SAVED_LOCATIONS);
+    expect(persistedState?.locations[0]?.id).toBe("location-0");
+    expect(persistedState?.locations.at(-1)?.id).toBe(
+      `location-${MAX_SAVED_LOCATIONS - 1}`,
+    );
+  });
+
+  it("persists dashboard state", () => {
+    savePersistedMulticityState({
+      sport: SportType.Croquet,
+      locations: [],
+    });
+
+    expect(storage.get(MULTICITY_STORAGE_KEY)).toBe(
+      JSON.stringify({
+        sport: SportType.Croquet,
+        locations: [],
+      }),
+    );
+  });
+});

--- a/frontend/src/pages/multicity/browserState.ts
+++ b/frontend/src/pages/multicity/browserState.ts
@@ -1,0 +1,117 @@
+import { MAX_SAVED_LOCATIONS, type SavedLocation } from "@/domain/multicity";
+import { DEFAULT_SPORT_TYPE, type SportType } from "@/domain/sport";
+import { isValidPersistedSport } from "@/pages/home/browserState";
+
+const MULTICITY_STORAGE_KEY = "multicity-locations:v1";
+
+export interface PersistedMulticityState {
+  sport: SportType;
+  locations: SavedLocation[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isValidSavedLocation(value: unknown): value is SavedLocation {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    typeof value.displayLabel === "string" &&
+    value.displayLabel.length > 0 &&
+    typeof value.name === "string" &&
+    value.name.length > 0 &&
+    typeof value.countryName === "string" &&
+    value.countryName.length > 0 &&
+    typeof value.latitude === "number" &&
+    Number.isFinite(value.latitude) &&
+    typeof value.longitude === "number" &&
+    Number.isFinite(value.longitude) &&
+    (value.regionName === undefined || typeof value.regionName === "string") &&
+    (value.mapboxId === undefined || typeof value.mapboxId === "string")
+  );
+}
+
+/**
+ * Loads and validates persisted multi-city dashboard state from localStorage.
+ */
+export function loadPersistedMulticityState(
+  allowedSports: readonly SportType[],
+): PersistedMulticityState | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(MULTICITY_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return null;
+    }
+
+    const locations = parsed.locations;
+
+    if (!Array.isArray(locations) || !locations.every(isValidSavedLocation)) {
+      return null;
+    }
+
+    const sport = isValidPersistedSport(parsed.sport, allowedSports)
+      ? parsed.sport
+      : DEFAULT_SPORT_TYPE;
+
+    return {
+      sport,
+      locations: locations.slice(0, MAX_SAVED_LOCATIONS),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists the latest multi-city dashboard state into localStorage (best-effort).
+ */
+export function savePersistedMulticityState(
+  state: PersistedMulticityState,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const payload: PersistedMulticityState = {
+      sport: state.sport,
+      locations: state.locations,
+    };
+
+    window.localStorage.setItem(MULTICITY_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Intentionally ignore storage errors to keep UI interaction unblocked.
+  }
+}
+
+/**
+ * Resolves the initial dashboard sport from persisted state or app defaults.
+ */
+export function resolveInitialMulticitySport(
+  persistedState: PersistedMulticityState | null,
+): SportType {
+  return persistedState?.sport ?? DEFAULT_SPORT_TYPE;
+}
+
+/**
+ * Resolves the initial saved locations list from persisted state.
+ */
+export function resolveInitialMulticityLocations(
+  persistedState: PersistedMulticityState | null,
+): SavedLocation[] {
+  return persistedState?.locations ?? [];
+}

--- a/frontend/src/pages/multicity/multicityToast.test.ts
+++ b/frontend/src/pages/multicity/multicityToast.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMulticityRiskUpdatedToast,
+  MULTICITY_SUCCESS_TOAST_DURATION_MS,
+} from "@/pages/multicity/multicityToast";
+
+describe("multicityToast", () => {
+  it("creates a short success toast for refreshed dashboard risk", () => {
+    expect(createMulticityRiskUpdatedToast(7)).toEqual({
+      id: 7,
+      i18nKey: "multicity.notifications.riskUpdated",
+      variant: "success",
+      durationMs: MULTICITY_SUCCESS_TOAST_DURATION_MS,
+    });
+  });
+});

--- a/frontend/src/pages/multicity/multicityToast.ts
+++ b/frontend/src/pages/multicity/multicityToast.ts
@@ -1,0 +1,24 @@
+export type MulticityToastVariant = "success" | "error";
+
+export const MULTICITY_SUCCESS_TOAST_DURATION_MS = 3000;
+
+export interface MulticityToastEvent {
+  id: number;
+  i18nKey: string;
+  variant: MulticityToastVariant;
+  durationMs?: number;
+}
+
+/**
+ * Creates a short success toast after a scheduled dashboard refetch.
+ */
+export function createMulticityRiskUpdatedToast(
+  id: number,
+): MulticityToastEvent {
+  return {
+    id,
+    i18nKey: "multicity.notifications.riskUpdated",
+    variant: "success",
+    durationMs: MULTICITY_SUCCESS_TOAST_DURATION_MS,
+  };
+}

--- a/frontend/src/pages/multicity/useMulticityBootstrap.ts
+++ b/frontend/src/pages/multicity/useMulticityBootstrap.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { SPORT_TYPE_VALUES } from "@/domain/sport";
+import {
+  loadPersistedMulticityState,
+  resolveInitialMulticityLocations,
+  resolveInitialMulticitySport,
+  savePersistedMulticityState,
+} from "@/pages/multicity/browserState";
+import { useMulticityStore } from "@/store/multicityStore";
+
+/**
+ * Bootstraps multi-city dashboard state from localStorage and keeps it persisted.
+ */
+export function useMulticityBootstrap(): void {
+  const isBootstrapped = useMulticityStore((state) => state.isBootstrapped);
+  const bootstrap = useMulticityStore((state) => state.bootstrap);
+  const sport = useMulticityStore((state) => state.sport);
+  const locations = useMulticityStore((state) => state.locations);
+
+  useEffect(() => {
+    if (isBootstrapped) {
+      return;
+    }
+
+    const persistedState = loadPersistedMulticityState(SPORT_TYPE_VALUES);
+    bootstrap({
+      sport: resolveInitialMulticitySport(persistedState),
+      locations: resolveInitialMulticityLocations(persistedState),
+    });
+  }, [bootstrap, isBootstrapped]);
+
+  useEffect(() => {
+    if (!isBootstrapped) {
+      return;
+    }
+
+    savePersistedMulticityState({
+      sport,
+      locations,
+    });
+  }, [isBootstrapped, locations, sport]);
+}

--- a/frontend/src/store/homeStore.test.ts
+++ b/frontend/src/store/homeStore.test.ts
@@ -156,4 +156,114 @@ describe("homeStore location search", () => {
       selectedLocation: DAMPER_LOCATION,
     });
   });
+
+  it("applies shared URL navigation when sport or location changes after bootstrap", () => {
+    useHomeStore.getState().bootstrap({
+      channel: "direct",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: DAMPER_LOCATION.displayLabel,
+      locationPrefillSource: "persisted",
+      prefilledLocationResolveState: "idle",
+    });
+    useHomeStore.getState().selectLocation(DAMPER_LOCATION);
+
+    useHomeStore.getState().applySharedUrlNavigation({
+      channel: "shared",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: "RUNNING",
+      locationSearchInput: PERTH_LOCATION.displayLabel,
+      locationPrefillSource: "url",
+      prefilledLocationResolveState: "pending",
+    });
+
+    expect(useHomeStore.getState()).toMatchObject({
+      channel: "shared",
+      sport: "RUNNING",
+      locationSearchInput: PERTH_LOCATION.displayLabel,
+      locationPrefillSource: "url",
+      prefilledLocationResolveState: "pending",
+      selectedLocation: null,
+    });
+    expect(useHomeStore.getState().locationSessionToken).not.toBe(
+      INITIAL_SESSION_TOKEN,
+    );
+
+    useHomeStore.getState().selectLocation(PERTH_LOCATION);
+
+    useHomeStore.getState().applySharedUrlNavigation({
+      channel: "shared",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: "RUNNING",
+      locationSearchInput: PERTH_LOCATION.displayLabel,
+      locationPrefillSource: "url",
+      prefilledLocationResolveState: "pending",
+    });
+
+    expect(useHomeStore.getState()).toMatchObject({
+      selectedLocation: PERTH_LOCATION,
+      locationSessionToken: useHomeStore.getState().locationSessionToken,
+    });
+  });
+
+  it("applies profile-only shared URL navigation without clearing the selected location", () => {
+    useHomeStore.getState().bootstrap({
+      channel: "direct",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: DAMPER_LOCATION.displayLabel,
+      locationPrefillSource: "persisted",
+      prefilledLocationResolveState: "idle",
+    });
+    useHomeStore.getState().selectLocation(DAMPER_LOCATION);
+    const sessionToken = useHomeStore.getState().locationSessionToken;
+
+    useHomeStore.getState().applySharedUrlNavigation({
+      channel: "shared",
+      profile: "AGE_14_17",
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: "",
+      locationPrefillSource: "url",
+      prefilledLocationResolveState: "idle",
+    });
+
+    expect(useHomeStore.getState()).toMatchObject({
+      channel: "shared",
+      profile: "AGE_14_17",
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: "",
+      locationPrefillSource: "url",
+      selectedLocation: DAMPER_LOCATION,
+      locationSessionToken: sessionToken,
+    });
+  });
+
+  it("applies channel-only shared URL navigation without clearing the selected location", () => {
+    useHomeStore.getState().bootstrap({
+      channel: "direct",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: DAMPER_LOCATION.displayLabel,
+      locationPrefillSource: "persisted",
+      prefilledLocationResolveState: "idle",
+    });
+    useHomeStore.getState().selectLocation(DAMPER_LOCATION);
+    const sessionToken = useHomeStore.getState().locationSessionToken;
+
+    useHomeStore.getState().applySharedUrlNavigation({
+      channel: "shared",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      sport: DEFAULT_SPORT_TYPE,
+      locationSearchInput: "",
+      locationPrefillSource: "url",
+      prefilledLocationResolveState: "idle",
+    });
+
+    expect(useHomeStore.getState()).toMatchObject({
+      channel: "shared",
+      profile: DEFAULT_HEAT_RISK_PROFILE,
+      selectedLocation: DAMPER_LOCATION,
+      locationSessionToken: sessionToken,
+    });
+  });
 });

--- a/frontend/src/store/homeStore.ts
+++ b/frontend/src/store/homeStore.ts
@@ -36,6 +36,7 @@ interface HomeStoreState {
   locationSessionToken: string;
 
   bootstrap: (payload: HomeStoreBootstrapPayload) => void;
+  applySharedUrlNavigation: (payload: HomeStoreBootstrapPayload) => void;
   setProfile: (profile: HeatRiskProfile) => void;
   setSport: (sport: SportType) => void;
   setLocationSearchInput: (value: string) => void;
@@ -89,6 +90,49 @@ export const useHomeStore = create<HomeStoreState>((set) => ({
       selectedLocation: null,
       prefilledLocationResolveState,
       locationSessionToken: createSessionToken(),
+    }),
+  applySharedUrlNavigation: ({
+    channel,
+    profile,
+    sport,
+    locationSearchInput,
+    locationPrefillSource,
+    prefilledLocationResolveState,
+  }) =>
+    set((state) => {
+      const nextLocationInput = locationSearchInput.trim();
+      const selectedLocationLabel =
+        state.selectedLocation?.displayLabel.trim() ?? "";
+      const locationChanged =
+        nextLocationInput.length > 0 &&
+        nextLocationInput !== selectedLocationLabel;
+      const sportChanged = sport !== state.sport;
+      const profileChanged = profile !== state.profile;
+      const channelChanged = channel !== state.channel;
+
+      if (
+        !locationChanged &&
+        !sportChanged &&
+        !profileChanged &&
+        !channelChanged
+      ) {
+        return state;
+      }
+
+      return {
+        channel,
+        profile,
+        sport,
+        locationSearchInput,
+        locationPrefillSource,
+        prefilledLocationResolveState,
+        ...(locationChanged
+          ? {
+              selectedLocation: null,
+              locationSessionToken: createSessionToken(),
+            }
+          : {}),
+      };
     }),
   setProfile: (profile) => set({ profile }),
   setSport: (sport) => set({ sport }),

--- a/frontend/src/store/multicityStore.test.ts
+++ b/frontend/src/store/multicityStore.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_SPORT_TYPE, SportType } from "@/domain/sport";
+import type { LocationSuggestion } from "@/domain/location";
+import { useMulticityStore } from "@/store/multicityStore";
+
+const SYDNEY_LOCATION: LocationSuggestion = {
+  id: "suggestion-sydney",
+  displayLabel: "Sydney, New South Wales, Australia",
+  name: "Sydney",
+  regionName: "New South Wales",
+  countryName: "Australia",
+  mapboxId: "mapbox-sydney",
+  latitude: -33.847,
+  longitude: 151.067,
+};
+
+const MELBOURNE_LOCATION: LocationSuggestion = {
+  id: "suggestion-melbourne",
+  displayLabel: "Melbourne, Victoria, Australia",
+  name: "Melbourne",
+  regionName: "Victoria",
+  countryName: "Australia",
+  mapboxId: "mapbox-melbourne",
+  latitude: -37.813,
+  longitude: 144.963,
+};
+
+function resetMulticityStore() {
+  useMulticityStore.setState({
+    isBootstrapped: false,
+    sport: DEFAULT_SPORT_TYPE,
+    locations: [],
+    locationSearchInput: "",
+    locationSessionToken: "session-initial",
+  });
+}
+
+describe("multicityStore", () => {
+  beforeEach(() => {
+    resetMulticityStore();
+  });
+
+  afterEach(() => {
+    resetMulticityStore();
+  });
+
+  it("bootstraps with persisted sport and locations", () => {
+    useMulticityStore.getState().bootstrap({
+      sport: SportType.Croquet,
+      locations: [
+        {
+          id: "location-1",
+          displayLabel: SYDNEY_LOCATION.displayLabel,
+          name: SYDNEY_LOCATION.name,
+          regionName: SYDNEY_LOCATION.regionName,
+          countryName: SYDNEY_LOCATION.countryName,
+          latitude: SYDNEY_LOCATION.latitude as number,
+          longitude: SYDNEY_LOCATION.longitude as number,
+        },
+      ],
+    });
+
+    expect(useMulticityStore.getState()).toMatchObject({
+      isBootstrapped: true,
+      sport: SportType.Croquet,
+      locations: [
+        expect.objectContaining({
+          name: "Sydney",
+        }),
+      ],
+    });
+  });
+
+  it("adds, reorders, and removes saved locations", () => {
+    expect(useMulticityStore.getState().addLocation(SYDNEY_LOCATION)).toEqual({
+      ok: true,
+    });
+    expect(
+      useMulticityStore.getState().addLocation(MELBOURNE_LOCATION),
+    ).toEqual({
+      ok: true,
+    });
+
+    const firstLocationId = useMulticityStore.getState().locations[0]?.id;
+    expect(firstLocationId).toBeDefined();
+
+    useMulticityStore.getState().moveLocationDown(firstLocationId as string);
+
+    expect(
+      useMulticityStore.getState().locations.map((location) => location.name),
+    ).toEqual(["Melbourne", "Sydney"]);
+
+    useMulticityStore.getState().removeLocation(firstLocationId as string);
+
+    expect(useMulticityStore.getState().locations).toHaveLength(1);
+    expect(useMulticityStore.getState().locations[0]?.name).toBe("Melbourne");
+  });
+
+  it("rejects duplicate locations", () => {
+    expect(useMulticityStore.getState().addLocation(SYDNEY_LOCATION)).toEqual({
+      ok: true,
+    });
+    expect(useMulticityStore.getState().addLocation(SYDNEY_LOCATION)).toEqual({
+      ok: false,
+      reason: "duplicate",
+    });
+  });
+});

--- a/frontend/src/store/multicityStore.ts
+++ b/frontend/src/store/multicityStore.ts
@@ -1,0 +1,144 @@
+import { create } from "zustand";
+import type { LocationSuggestion } from "@/domain/location";
+import {
+  createSavedLocationFromSuggestion,
+  type AddLocationResult,
+  type SavedLocation,
+  validateAddSavedLocation,
+} from "@/domain/multicity";
+import { DEFAULT_SPORT_TYPE, type SportType } from "@/domain/sport";
+
+export interface MulticityStoreBootstrapPayload {
+  sport: SportType;
+  locations: SavedLocation[];
+}
+
+interface MulticityStoreState {
+  isBootstrapped: boolean;
+  sport: SportType;
+  locations: SavedLocation[];
+  locationSearchInput: string;
+  locationSessionToken: string;
+
+  bootstrap: (payload: MulticityStoreBootstrapPayload) => void;
+  setSport: (sport: SportType) => void;
+  setLocationSearchInput: (value: string) => void;
+  addLocation: (suggestion: LocationSuggestion) => AddLocationResult;
+  removeLocation: (locationId: string) => void;
+  moveLocationUp: (locationId: string) => void;
+  moveLocationDown: (locationId: string) => void;
+}
+
+function createSessionToken(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function reorderLocations(
+  locations: SavedLocation[],
+  locationId: string,
+  direction: -1 | 1,
+): SavedLocation[] {
+  const currentIndex = locations.findIndex(
+    (location) => location.id === locationId,
+  );
+
+  if (currentIndex === -1) {
+    return locations;
+  }
+
+  const targetIndex = currentIndex + direction;
+  if (targetIndex < 0 || targetIndex >= locations.length) {
+    return locations;
+  }
+
+  const nextLocations = [...locations];
+  const [movedLocation] = nextLocations.splice(currentIndex, 1);
+  nextLocations.splice(targetIndex, 0, movedLocation);
+  return nextLocations;
+}
+
+/**
+ * Central multi-city dashboard store for sport and saved locations.
+ */
+export const useMulticityStore = create<MulticityStoreState>((set, get) => ({
+  isBootstrapped: false,
+  sport: DEFAULT_SPORT_TYPE,
+  locations: [],
+  locationSearchInput: "",
+  locationSessionToken: createSessionToken(),
+
+  bootstrap: ({ sport, locations }) => {
+    set({
+      isBootstrapped: true,
+      sport,
+      locations,
+      locationSearchInput: "",
+      locationSessionToken: createSessionToken(),
+    });
+  },
+
+  setSport: (sport) => {
+    set({ sport });
+  },
+
+  setLocationSearchInput: (value) => {
+    const trimmedValue = value.trim();
+    const previousValue = get().locationSearchInput.trim();
+    const shouldRefreshSessionToken =
+      trimmedValue.length > 0 && previousValue.length === 0;
+
+    set((state) => ({
+      locationSearchInput: value,
+      locationSessionToken: shouldRefreshSessionToken
+        ? createSessionToken()
+        : state.locationSessionToken,
+    }));
+  },
+
+  addLocation: (suggestion) => {
+    const validation = validateAddSavedLocation(get().locations, suggestion);
+    if (!validation.ok) {
+      return validation;
+    }
+
+    const savedLocation = createSavedLocationFromSuggestion({
+      ...suggestion,
+      latitude: suggestion.latitude as number,
+      longitude: suggestion.longitude as number,
+    });
+
+    set((state) => ({
+      locations: [...state.locations, savedLocation],
+      locationSearchInput: "",
+    }));
+
+    return { ok: true };
+  },
+
+  removeLocation: (locationId) => {
+    set((state) => ({
+      locations: state.locations.filter(
+        (location) => location.id !== locationId,
+      ),
+    }));
+  },
+
+  moveLocationUp: (locationId) => {
+    set((state) => ({
+      locations: reorderLocations(state.locations, locationId, -1),
+    }));
+  },
+
+  moveLocationDown: (locationId) => {
+    set((state) => ({
+      locations: reorderLocations(state.locations, locationId, 1),
+    }));
+  },
+}));


### PR DESCRIPTION
### Summary
- Adds a Multi-city dashboard at /multicity so users can save up to 6 cities, pick a sport independently of Home, and compare today’s heat risk (current and max for day). Clicking a card opens Home with selected sport and location.
- New POST /home/risk/batch which has one request for all saved cities, with per-city ok/error and HTTP 200 on partial failure. Successful summaries use a separate in-memory TTL cache from Home forecast cache.

Closes #55.

### What the code does
1. Page /multicity: Cities restore from localStorage (multicity-locations:v1). Sport lives only in MulticityStore (separate from Home). 
2. Add city via the same Mapbox suggest/retrieve as Home. The store keeps name + coords. Max 6 cities; duplicates are the same Mapbox id or the same lat/lng at 6 decimals.
3. With more than 1 city, the client sends one POST /home/risk/batch with { sport, profile: ADULT, locations: [{lat, lng}, ...] }.
4. Backend: validate 1–6 coords → dashboard summary cache (sport + profile + exact coords) → misses get timezone, Open-Meteo in chunks of 10 with a 2-day window, then the same MRT + heat model as Home. Response is a short per-city row: current_risk_level_interpolated (forecast[0]), today_max_risk_level_interpolated (max on that city’s local calendar day of the first forecast hour), or a per-city error.
5. Frontend maps rows to cards by lat/lng rounded to 6 decimals. Reorder does not refetch (query key sorts coords). React Query holds the batch; the page runs a ~20-minute refresh timer while the route is open (same as Home).
6. Click card → /?sport=...&loc=CityName. Home treats that as shared-link navigation (applySharedUrlNavigation + URL-sync guards) so an already-mounted Home does not write the previous city back over the click.

### Key design decisions

- Maximum 6 cities can be added. 
- Sport filter is independent of Home.
- New summary API created to fetch only necessary data for current and today’s max risk.
- Uses same heat risk model as Home
- Click card to Home uses city name in the URL, so Home may search Mapbox again. Same contract as a shared Home link.

### Tests conducted
- Automated: All pnpm test:ci 216 tests passed and pytest 90 tests passed
- Manual test conducted and passed (i.e. can add/remove/reorder city cards on dashboard, dashboard cards link to home page with city/sport populated).

### Further work
- Navigation bar in Desktop view needs to be redesigned as there is not enough room for the additional button for multi-city dashboard.
- When merged with the language selector, simplified chinese translations were added for the dashboard. This was done using AI and translations need to be checked and confirmed.

### Screenshot of dashboard
<img width="723" height="610" alt="Dashboard Desktop" src="https://github.com/user-attachments/assets/cbbbda4e-8b07-471a-bf7f-57144917b675" />

<img width="495" height="760" alt="Dashboard mobile" src="https://github.com/user-attachments/assets/0020e681-3948-433c-b3e8-3bd0ee870e2d" />

